### PR TITLE
fix for factory_girl_rails to not depend on outdated rails 3 packages, among other things

### DIFF
--- a/factory_girl_rails.gemspec
+++ b/factory_girl_rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.authors = ["Joe Ferris"]
   s.email   = %q{jferris@thoughtbot.com}
   s.homepage = "http://github.com/thoughtbot/factory_girl_rails"
-  s.add_runtime_dependency('rails', '>= 3.0.0.beta4')
+  s.add_runtime_dependency('rails', '>= 3.0.0')
   s.add_runtime_dependency('factory_girl', '~> 1.3')
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')

--- a/features/load_definitions.feature
+++ b/features/load_definitions.feature
@@ -5,11 +5,11 @@ Feature: automatically load step definitions
     And I save the following as "Gemfile"
       """
       source "http://rubygems.org"
-      gem 'rails', '3.0.0.beta4'
+      gem 'rails', '3.0.0'
       gem 'sqlite3-ruby', :require => 'sqlite3'
       gem 'factory_girl_rails', :path => '../../'
       """
-    When I run "bundle lock"
+    When I run "bundle install"
     And I save the following as "db/migrate/1_create_users.rb"
       """
       class CreateUsers < ActiveRecord::Migration

--- a/lib/factory_girl_rails/railtie.rb
+++ b/lib/factory_girl_rails/railtie.rb
@@ -1,14 +1,14 @@
 require 'factory_girl'
 require 'rails'
 
-module FactoryGirl
+class Factory
   class Railtie < Rails::Railtie
     config.after_initialize do
-      FactoryGirl.definition_file_paths = [
+      Factory.definition_file_paths = [
         File.join(Rails.root, 'test', 'factories'),
         File.join(Rails.root, 'spec', 'factories')
       ]
-      FactoryGirl.find_definitions
+      Factory.find_definitions
     end
   end
 end


### PR DESCRIPTION
Installing factory_girl_rails will cause rails packages for 3.0.0.rc2 to be installed, even when 3.0.0 is already installed.  Also, bundle lock (in the factory_girl_rails cucumber feature) is deprecated in 1.0.0.  The FactoryGirl module also appears to not exist anymore in factory_girl 1.3.2.
