### PR TITLE
Load factories from /factories at the Rails root, just like the default definition_file_paths.

### DIFF
--- a/lib/factory_girl_rails/railtie.rb
+++ b/lib/factory_girl_rails/railtie.rb
@@ -5,6 +5,7 @@ module FactoryGirl
   class Railtie < Rails::Railtie
     config.after_initialize do
       FactoryGirl.definition_file_paths = [
+        File.join(Rails.root, 'factories'),
         File.join(Rails.root, 'test', 'factories'),
         File.join(Rails.root, 'spec', 'factories')
       ]


### PR DESCRIPTION
Load factories from /factories at the Rails root, just like the default definition_file_paths.
