### PR TITLE
Correct whitespace generated by factory template.

### DIFF
--- a/lib/generators/factory_girl/model/templates/fixtures.rb
+++ b/lib/generators/factory_girl/model/templates/fixtures.rb
@@ -2,8 +2,8 @@
 
 FactoryGirl.define do
   factory :<%= singular_name %> do
-  <% for attribute in attributes -%>
+<% for attribute in attributes -%>
     <%= attribute.name %> <%= attribute.default.inspect %>
-  <% end -%>
+<% end -%>
   end
 end


### PR DESCRIPTION
I've updated the factory template to print the whitespace nicer.  Most conventions call for a newline at the end of the file, and one of the `end`'s was indented an extra time.

This will generate a template looking like:

``` ruby
# Read about factories at http://github.com/thoughtbot/factory_girl

FactoryGirl.define do
  factory :address do
    street1 "MyString"
  end
end

```

rather than:

``` ruby
# Read about factories at http://github.com/thoughtbot/factory_girl

FactoryGirl.define do
  factory :address do
    street1 "MyString"
    end
end
```
