### PR TITLE
Respect model namespaces when generating factories.

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -10,4 +10,8 @@ Feature:
     And I add "factory_girl_rails" from this project as a dependency
     When I successfully run `bundle install`
     And I successfully run `bundle exec rails generate model User name:string --fixture-replacement=factory_girl`
+    And I successfully run `bundle exec rails generate model Namespaced::User name:string --fixture-replacement=factory_girl`
     Then the output should contain "test/factories/users.rb"
+    And the output should contain "test/factories/namespaced_users.rb"
+    And the file "test/factories/users.rb" should contain "factory :user do"
+    And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, :class => 'Namespaced::User' do"

--- a/lib/generators/factory_girl.rb
+++ b/lib/generators/factory_girl.rb
@@ -6,6 +6,10 @@ module FactoryGirl
       def self.source_root
         @_factory_girl_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'factory_girl', generator_name, 'templates'))
       end
+
+      def explicit_class_option
+        ", :class => '#{class_name}'" unless class_name == singular_table_name.camelize
+      end
     end
   end
 end

--- a/lib/generators/factory_girl/model/templates/fixtures.rb
+++ b/lib/generators/factory_girl/model/templates/fixtures.rb
@@ -1,7 +1,7 @@
 # Read about factories at https://github.com/thoughtbot/factory_girl
 
 FactoryGirl.define do
-  factory :<%= singular_name %> do
+  factory :<%= singular_table_name %><%= explicit_class_option %> do
 <% for attribute in attributes -%>
     <%= attribute.name %> <%= attribute.default.inspect %>
 <% end -%>


### PR DESCRIPTION
The factory name for the model Namespaced::User wil be :namespaced_user.
The :class option is specified as a string to prevent class reloading issues.

Addresses GH-44
