### PR TITLE
disable factory model generator

### DIFF
--- a/lib/factory_girl_rails/railtie.rb
+++ b/lib/factory_girl_rails/railtie.rb
@@ -8,7 +8,9 @@ module FactoryGirl
       generators = config.respond_to?(:app_generators) ? config.app_generators : config.generators
 
       if generators.options[:rails][:test_framework] == :rspec
-        generators.fixture_replacement :factory_girl, :dir => 'spec/factories'
+        unless generators.options[:rails][:factories] == false
+          generators.fixture_replacement :factory_girl, :dir => 'spec/factories'
+        end
       else
         generators.test_framework :test_unit, :fixture => false, :fixture_replacement => :factory_girl
       end


### PR DESCRIPTION
can disable factories from being generated

```
config.generators do |g|
  g.factories false
end
```
