### PR TITLE
Change Rails Dependency to greater than 3.0.7

### DIFF
--- a/factory_girl_rails.gemspec
+++ b/factory_girl_rails.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.6.0')
   s.add_development_dependency('cucumber', '~> 1.0.0')
   s.add_development_dependency('aruba')
-  s.add_development_dependency('rails', '3.0.7')
+  s.add_development_dependency('rails', '>= 3.0.7')
 end


### PR DESCRIPTION
I ran into this issue when installing Factory Girl Rails

Invalid gemspec in [/home/vagrant/.rbenv/versions/1.8.7-p352/lib/ruby/gems/1.8/specifications/factory_girl_rails-1.7.0.gemspec]: Illformed requirement ["#YAML::Syck::DefaultKey:0xb6f2d33c 3.0.7"]
Invalid gemspec in [/home/vagrant/.rbenv/versions/1.8.7-p352/lib/ruby/gems/1.8/specifications/factory_girl_rails-1.7.0.gemspec]: Illformed requirement ["#YAML::Syck::DefaultKey:0xb6f2d33c 3.0.7"]
Invalid gemspec in [/home/vagrant/.rbenv/versions/1.8.7-p352/lib/ruby/gems/1.8/specifications/factory_girl_rails-1.7.0.gemspec]: Illformed requirement ["#YAML::Syck::DefaultKey:0xb6f2d33c 3.0.7"]
Invalid gemspec in [/home/vagrant/.rbenv/versions/1.8.7-p352/lib/ruby/gems/1.8/specifications/factory_girl_rails-1.7.0.gemspec]: Illformed requirement ["#YAML::Syck::DefaultKey:0xb6f2d33c 3.0.7"]
Could not find factory_girl_rails-1.7.0 in any of the sources
Run `bundle install` to install missing gems.

I didn't have Rails 3.0.7 installed on my machine.  This should fix that issue of not having Rails 3.0.7 during development.  
