### PR TITLE
Use a previously-selected :dir from application.rb

### DIFF
--- a/features/fixture_replacement_config.feature
+++ b/features/fixture_replacement_config.feature
@@ -29,3 +29,13 @@ Feature:
       | spec/factories/users.rb |
     And the following files should not exist:
       | spec/fixtures/users.yml |
+
+  Scenario: Using Factory Girl and Factory Girl Rails with RSpec should generate a factory file in a preferred location
+    And I add "rspec-rails" as a dependency
+    And I set the FactoryGirl :dir option to "spec/support/factories"
+    And I successfully run `bundle install`
+    And I successfully run `bundle exec rails generate model User name:string`
+    Then the following files should exist:
+      | spec/support/factories/users.rb |
+    And the following files should not exist:
+      | spec/fixtures/users.yml |

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -5,3 +5,15 @@ end
 When /^I add "([^"]+)" as a dependency$/ do |gem_name|
   append_to_file('Gemfile', %{gem "#{gem_name}"\n})
 end
+
+When /^I set the FactoryGirl :dir option to "([^"]+)"$/ do |directory|
+  append_to_file('config/application.rb', <<-RUBY)
+    module Testapp
+      class Application < Rails::Application
+        config.generators do |g|
+          g.fixture_replacement :factory_girl, :dir => '#{directory}'
+        end
+      end
+    end
+  RUBY
+end


### PR DESCRIPTION
factory_girl_rails currently ignores a previously-supplied :dir option from application.rb, and therefore always generates factories at spec/factories when RSpec is being used.

This patch will respect the user-supplied option, if given.
