### PR TITLE
Generator: Module missing for Model in mountable engine

### DIFF
--- a/lib/generators/factory_girl.rb
+++ b/lib/generators/factory_girl.rb
@@ -8,7 +8,11 @@ module FactoryGirl
       end
 
       def explicit_class_option
-        ", :class => '#{class_name}'" unless class_name == singular_table_name.camelize
+        unless class_name == singular_table_name.camelize
+          output = ", :class => "
+          output << namespace.to_s << "::" if namespaced?
+          output << class_name
+        end
       end
     end
   end


### PR DESCRIPTION
If I create a new Model with i.e. `rails g Model Widged title:string` in a **_mountable**_ rails engine the resulting factory gets only partially namespaced/modularized:

``` ruby
FactoryGirl.define do
  factory :widged_factory_widged, :class => 'Widged' do
    title "MyString"
  end
end
```

I would expect something like this:

``` ruby
FactoryGirl.define do
  factory :widged_factory_widged, :class => WidgedFactory:Widged  do
    title "MyString"
  end
end
```

If you need a sample mountable rails engine to verify this I'll happyily provide one.
