### PR TITLE
Fix travis build fail by forcing empty bundler_args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - gem update --system
   - gem install turn --version 0.8.2
   - gem install turn --version 0.8.3
+bundler_args: ""
 jdk:
   - openjdk6
 gemfile:


### PR DESCRIPTION
This should fix #122.

Travis build status:
Before: https://travis-ci.org/thoughtbot/factory_girl_rails/builds/15525438
Now: https://travis-ci.org/seekshiva/factory_girl_rails/builds/16397814
