### PR TITLE
Add correct link to `CONTRIBUTING.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ factory_girl takes an option `suffix: 'some_suffix'` to generate factories as
 
 ## Contributing
 
-Please see [CONTRIBUTING.md]().
+Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Credits
 


### PR DESCRIPTION
- Plain text rendered as `[CONTRIBUTING.md]().` which lead to
  https://github.com/thoughtbot/factory_girl_rails/blob/master (404)
