### PR TITLE
Add spaces

### DIFF
--- a/lib/generators/factory_girl/model/model_generator.rb
+++ b/lib/generators/factory_girl/model/model_generator.rb
@@ -71,7 +71,7 @@ RUBY
       def factory_attributes
         attributes.map do |attribute|
           "#{attribute.name} #{attribute.default.inspect}"
-        end.join("\n")
+        end.join("\n    ")
       end
 
       def filename


### PR DESCRIPTION
if we exec `rails generate model sample_model hoge:integer fuga:integer` then the generated factory file does not have correct indent spaces like following, 

```
FactoryGirl.define do
  factory :sample_model do
    hoge 1
fuga 1
  end

end
```

This PR will fix this.
