### PR TITLE
Revert to using template

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,8 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     jruby-openssl (0.9.6-java)
-    json (1.8.1)
-    json (1.8.1-java)
+    json (1.8.3)
+    json (1.8.3-java)
     minitest (5.3.4)
     multi_json (1.11.0)
     multi_test (0.1.2)
@@ -141,4 +141,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    factory_girl_rails (4.6.0)
-      factory_girl (~> 4.5.0)
+    factory_girl_rails (4.6.1)
+      factory_girl (~> 4.0)
       railties (>= 3.0.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ will generate standard .yml files instead of factory files.
 factory_girl takes an option `suffix: 'some_suffix'` to generate factories as
 `modelname_some_suffix.rb`.
 
-If you use factory_girl for fixture replacement and already have a
-`factories.rb` file in the directory that contains your tests,
-factory_girl_rails will insert new factory definitions at the top of
-`factories.rb`.
-
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/factory_girl_rails.gemspec
+++ b/factory_girl_rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = %q{factory_girl_rails}
-  s.version     = '4.6.0'
+  s.version     = '4.6.1'
   s.authors     = ["Joe Ferris"]
   s.email       = %q{jferris@thoughtbot.com}
   s.homepage    = "http://github.com/thoughtbot/factory_girl_rails"
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_runtime_dependency('railties', '>= 3.0.0')
-  s.add_runtime_dependency('factory_girl', '~> 4.5.0')
+  s.add_runtime_dependency('factory_girl', '~> 4.0')
 end

--- a/features/generators.feature
+++ b/features/generators.feature
@@ -8,7 +8,7 @@ Feature:
     And I cd to "testapp"
     And I add "factory_girl_rails" from this project as a dependency
 
-  Scenario: The factory_girl_rails generators create a factory file for each model if there is not a factories.rb file
+  Scenario: The factory_girl_rails generators create a factory file for each model that I generate
     When I run `bundle install` with a clean environment
     And I run `bundle exec rails generate model User name:string age:integer` with a clean environment
     And I run `bundle exec rails generate model Namespaced::User name:string` with a clean environment
@@ -26,29 +26,12 @@ Feature:
       """
     And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, class: 'Namespaced::User' do"
 
-  Scenario: The factory_girl_rails generators add a factory in the correct spot
+  Scenario: The factory_girl_rails generators create a factory file with a custom name for each model that I generate
     When I run `bundle install` with a clean environment
-    And I write to "test/factories.rb" with:
-      """
-      FactoryGirl.define do
-      end
-      """
-    And I run `bundle exec rails generate model User name:string` with a clean environment
-    Then the file "test/factories.rb" should contain exactly:
-      """
-      FactoryGirl.define do
-        factory :user do
-          name "MyString"
-        end
-      end
-      """
-
-  Scenario: The factory_girl_rails generators does not create a factory file for each model if there is a factories.rb file in the test directory
-    When I run `bundle install` with a clean environment
-    And I write to "test/factories.rb" with:
-      """
-      FactoryGirl.define do
-      end
-      """
-    And I run `bundle exec rails generate model User name:string` with a clean environment
-    Then the file "test/factories.rb" should contain "factory :user do"
+    And I set the FactoryGirl :suffix option to "factory"
+    And I run `bundle exec rails generate model User name:string --fixture-replacement=factory_girl` with a clean environment
+    And I run `bundle exec rails generate model Namespaced::User name:string --fixture-replacement=factory_girl` with a clean environment
+    Then the output should contain "test/factories/users_factory.rb"
+    And the output should contain "test/factories/namespaced_users_factory.rb"
+    And the file "test/factories/users_factory.rb" should contain "factory :user do"
+    And the file "test/factories/namespaced_users_factory.rb" should contain "factory :namespaced_user, :class => 'Namespaced::User' do"

--- a/lib/generators/factory_girl/model/model_generator.rb
+++ b/lib/generators/factory_girl/model/model_generator.rb
@@ -4,75 +4,15 @@ require 'factory_girl_rails'
 module FactoryGirl
   module Generators
     class ModelGenerator < Base
-      argument(
-        :attributes,
-        type: :array,
-        default: [],
-        banner: "field:type field:type"
-      )
-
-      class_option(
-        :dir,
-        type: :string,
-        default: "test/factories",
-        desc: "The directory or file root where factories belong"
-      )
-
-      class_option(
-        :suffix,
-        type: :string,
-        default: nil,
-        desc: "Suffix to add factory file"
-      )
+      argument :attributes, type: :array, default: [], banner: "field:type field:type"
+      class_option :dir, type: :string, default: "test/factories", desc: "The directory where the factories should go"
+      class_option :suffix, type: :string, default: nil, desc: "Suffix to add factory file"
 
       def create_fixture_file
-        if File.exist?(factories_file)
-          insert_factory_into_existing_file
-        else
-          create_factory_file
-        end
+        template 'fixtures.erb', File.join(options[:dir], "#{filename}.rb")
       end
 
       private
-
-      def factories_file
-        options[:dir] + ".rb"
-      end
-
-      def insert_factory_into_existing_file
-        insert_into_file(
-          factories_file,
-          factory_definition,
-          after: "FactoryGirl.define do\n"
-        )
-      end
-
-      def create_factory_file
-        file = File.join(options[:dir], "#{filename}.rb")
-        create_file(file, single_file_factory_definition)
-      end
-
-      def factory_definition
-<<-RUBY
-  factory :#{singular_table_name}#{explicit_class_option} do
-#{factory_attributes.gsub(/^/, "    ")}
-  end
-RUBY
-      end
-
-      def single_file_factory_definition
-<<-RUBY
-FactoryGirl.define do
-#{factory_definition.chomp}
-end
-RUBY
-      end
-
-      def factory_attributes
-        attributes.map do |attribute|
-          "#{attribute.name} #{attribute.default.inspect}"
-        end.join("\n")
-      end
 
       def filename
         if factory_girl_options[:filename_proc].present?
@@ -86,13 +26,13 @@ RUBY
         factory_girl_options[:suffix] || options[:suffix]
       end
 
-      def factory_girl_options
-        generators.options[:factory_girl] || {}
-      end
-
       def generators
         config = FactoryGirl::Railtie.config
         config.respond_to?(:app_generators) ? config.app_generators : config.generators
+      end
+
+      def factory_girl_options
+        generators.options[:factory_girl] || {}
       end
     end
   end

--- a/lib/generators/factory_girl/model/templates/fixtures.erb
+++ b/lib/generators/factory_girl/model/templates/fixtures.erb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :<%= singular_table_name %><%= explicit_class_option %> do
+<% for attribute in attributes -%>
+    <%= attribute.name %> <%= attribute.default.inspect %>
+<% end -%>
+  end
+end


### PR DESCRIPTION
Hello, 

The Rails standard assumes using templates in generators. As I've written a gem that enhances the factory_girl template, it can not be used when no template is utilized by gem.

Yes, the feature to keep all the factories in one file is lost. But it is not so important for real projects as ability to use my 'factory_girl_fixtures_template' additions.

Thank you in advance for understanding.

P.S. I think the feature to keep all the generated factories in one file can be restored with template too, But I have not time to do it now. ;-)
