### PR TITLE
Avoid loading factory definitions in spring server process

### DIFF
--- a/lib/factory_girl_rails/railtie.rb
+++ b/lib/factory_girl_rails/railtie.rb
@@ -18,10 +18,10 @@ module FactoryGirl
     end
 
     config.after_initialize do
-      FactoryGirl.find_definitions
-
       if defined?(Spring)
         Spring.after_fork { FactoryGirl.reload }
+      else
+        FactoryGirl.find_definitions
       end
     end
   end


### PR DESCRIPTION
It appears that when running within spring the factories' code is loaded on initial load in the server process, but only to be removed and re-initialized on fork. 

This causes problems when the factories contain code that affects the global environment, e.g. if you have code like

```
CONSTANT_DATA = some_expensive_operation()
FactoryGirl.define do
  factory :foo do
    data { make use of CONSTANT_DATA }
  end
end
```

you'll receive a warning on constant redefinition, on each spring-based command run.

This seems reated to the issue that affects people in https://github.com/thoughtbot/factory_girl_rails/issues/134

AFAICT,  `FactoryGirl.reload` ends up calling `find_definitions` by itself, so doing it also in the spring server process seems unnecessary. 
