### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/factory_bot_rails.gemspec
+++ b/factory_bot_rails.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version     = '4.8.2'
   s.authors     = ["Joe Ferris"]
   s.email       = %q{jferris@thoughtbot.com}
-  s.homepage    = "http://github.com/thoughtbot/factory_bot_rails"
+  s.homepage    = "https://github.com/thoughtbot/factory_bot_rails"
   s.summary     = %q{factory_bot_rails provides integration between
     factory_bot and rails 3 or newer}
   s.description = %q{factory_bot_rails provides integration between


### PR DESCRIPTION
This reduces unneeded redirection from `http://...` to `https://...` when someone visits this gem's homepage via https://rubygems.org/gems/factory_bot_rails