### PR TITLE
Run the factory definition search after ActiveRecord is loaded

### DIFF
--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -18,7 +18,7 @@ module FactoryBot
     end
 
     config.after_initialize do
-      FactoryBot.find_definitions
+      ActiveSupport.on_load(:active_record) { FactoryBot.find_definitions }
 
       if defined?(Spring)
         Spring.after_fork { FactoryBot.reload }

--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -5,10 +5,10 @@ require 'rails'
 module FactoryBot
   class Railtie < Rails::Railtie
     ORMS_USING_LOAD_HOOKS = {
-      'Mongoid' => :mongoid,
-      'SequelRails' => :sequel,
-      'MongoMapper' => :mongo_mapper,
-      'ActiveRecord' => :active_record,
+      "Mongoid" => :mongoid,
+      "SequelRails" => :sequel,
+      "MongoMapper" => :mongo_mapper,
+      "ActiveRecord" => :active_record,
       # datamapper doesn't seem to use load hooks...
     }.freeze
 


### PR DESCRIPTION
This PR makes the Railtie to wait for ActiveRecord to be loaded before running the `FactoryBot.find_definitions` routine, which currently may load models before ActiveRecord is loaded, causing problems on some cases (i.e. doorkeeper-gem/doorkeeper#1043), specially when referencing ActiveRecord models in the `class` option inside a factory definition.