### PR TITLE
Drop jruby & add modern Rubies to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,10 @@ matrix:
   allow_failures:
     - rvm: 2.1
       gemfile: gemfiles/rails5.0.gemfile
+    # Ruby 2.4+ doesn't work with ActiveSupport 4.1
+    # https://github.com/rails/rails/pull/25161
+    # https://github.com/rails/rails/pull/25737
+    - rvm: 2.4
+      gemfile: gemfiles/rails4.1.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/rails4.1.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,16 @@ before_install:
   - gem cleanup bundler
 cache: bundler
 rvm:
-  - 2.1.5
-  - 2.2.4
-  - 2.3.0
-  - jruby-19mode
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 branches:
   only:
     - master
 install:
-  - "travis_retry bundle install --jobs 8"
+  - "bundle install --retry 3 --jobs 8"
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.1.gemfile
@@ -24,7 +25,5 @@ gemfile:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: jruby-19mode
-      gemfile: gemfiles/rails5.0.gemfile
-    - rvm: 2.1.5
+    - rvm: 2.1
       gemfile: gemfiles/rails5.0.gemfile


### PR DESCRIPTION
`factory_bot` [dropped `jruby-19`](https://github.com/thoughtbot/factory_bot/commit/9f1b32e07100d9a7da5439532b14cb7c349a2563#diff-354f30a63fb0907d4ad57269548329e3) from the testing matrix almost a year ago and the `factory_bot_rails` build has been [broken for some time](https://travis-ci.org/thoughtbot/factory_bot_rails/builds) (~ 3 years).

Also makes the Rails `4.1` appraisal with Ruby 2.4 / 2.5 an 'allowed failure' because some tests fail with ActiveSupport `4.1` (this fix doesn't appear to have been backdated):
https://github.com/rails/rails/pull/25161
https://github.com/rails/rails/pull/25737

Planning to add Rails `5.1` and `5.2` appraisals in a subsequent PR.