### PR TITLE
Test against Rails 5.1 and 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,17 @@ gemfile:
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
+  - gemfiles/rails5.1.gemfile
+  - gemfiles/rails5.2.gemfile
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: ruby-head
+  exclude:
     - rvm: 2.1
-      gemfile: gemfiles/rails5.0.gemfile
+      gemfiles/rails5.0gemfile
+    - rvm: 2.1
+      gemfiles/rails5.1gemfile
+    - rvm: 2.1
+      gemfiles/rails5.2gemfile
     # Ruby 2.4+ doesn't work with ActiveSupport 4.1
     # https://github.com/rails/rails/pull/25161
     # https://github.com/rails/rails/pull/25737
@@ -36,3 +41,5 @@ matrix:
       gemfile: gemfiles/rails4.1.gemfile
     - rvm: 2.5
       gemfile: gemfiles/rails4.1.gemfile
+  allow_failures:
+    - rvm: ruby-head

--- a/Appraisals
+++ b/Appraisals
@@ -14,8 +14,17 @@ appraise 'rails4.2' do
   gem 'rails', '~> 4.2.0'
 end
 
-appraise "rails5.0" do
-  gem "activerecord", "~> 5.0.0"
-  gem "railties", "~> 5.0.0"
-  gem "rspec-rails", "~> 3.5.0.beta4"
+appraise 'rails5.0' do
+  gem 'activerecord', '~> 5.0.0'
+  gem 'railties', '~> 5.0.0'
+end
+
+appraise 'rails5.1' do
+  gem 'activerecord', '~> 5.1.0'
+  gem 'railties', '~> 5.1.0'
+end
+
+appraise 'rails5.2' do
+  gem 'activerecord', '~> 5.2.0'
+  gem 'railties', '~> 5.2.0'
 end

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -16,7 +16,7 @@ gem "jdbc-sqlite3", :platforms => :jruby
 gem "therubyrhino", :platforms => :jruby
 gem "jruby-openssl", :platforms => :jruby
 gem "sqlite3", :platforms => :ruby
-gem "activerecord", "~> 5.0.0"
-gem "railties", "~> 5.0.0"
+gem "activerecord", "~> 5.1.0"
+gem "railties", "~> 5.1.0"
 
 gemspec :name => "factory_bot_rails", :path => "../"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -16,7 +16,7 @@ gem "jdbc-sqlite3", :platforms => :jruby
 gem "therubyrhino", :platforms => :jruby
 gem "jruby-openssl", :platforms => :jruby
 gem "sqlite3", :platforms => :ruby
-gem "activerecord", "~> 5.0.0"
-gem "railties", "~> 5.0.0"
+gem "activerecord", "~> 5.2.0"
+gem "railties", "~> 5.2.0"
 
 gemspec :name => "factory_bot_rails", :path => "../"


### PR DESCRIPTION
- Add Rails 5.1 and 5.2 to Appraisal
- Avoid running combinations we know are going to fail by moving to
"exclude" instead of "allow_failures"