### PR TITLE
Add version and SemVer stability badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# factory_bot_rails [![Build Status][ci-image]][ci] [![Code Climate][grade-image]][grade]
+# factory_bot_rails [![Build Status][ci-image]][ci] [![Code Climate][grade-image]][grade] [![Gem Version][version-image]][version]
 
 [factory_bot][fb] is a fixtures replacement with a straightforward definition
 syntax, support for multiple build strategies (saved instances, unsaved
@@ -103,3 +103,5 @@ We are [available for hire][hire].
 [grade-image]: https://codeclimate.com/github/thoughtbot/factory_bot_rails.svg
 [community]: https://thoughtbot.com/community?utm_source=github
 [hire]: https://thoughtbot.com/hire-us?utm_source=github
+[version-image]: https://badge.fury.io/rb/factory_bot_rails.svg
+[version]: https://badge.fury.io/rb/factory_bot_rails


### PR DESCRIPTION
First of all, thanks for factory_bot! I use it everywhere and my tests are way cleaner for it.

Would you be up for adding a badge showing how stable / bug-free new releases are? I realised we've got the data to show that at Dependabot, so I threw together the below:

[![Gem Version](https://badge.fury.io/rb/factory_bot_rails.svg)](http://badge.fury.io/rb/factory_bot_rails) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=factory_bot_rails&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=factory_bot_rails&package-manager=bundler&version-scheme=semver)

The gem version badge is totally standard. The semver stability one is based on all of the updates Dependabot has done for factory_bot users - if you click through there's a description of how it's calculated, but basically it's the percentage of SemVer compatible updates for factory_bot that users of the gem have done which have passed CI.

The idea is that together they give exactly the right information for users to decide what version requirement to put in their Gemfile (as suggested in your blog post [here](https://robots.thoughtbot.com/a-healthy-bundle)).