### PR TITLE
Don't run Rails 4.1 with Ruby head on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,7 @@ matrix:
       gemfile: gemfiles/rails4.1.gemfile
     - rvm: 2.5
       gemfile: gemfiles/rails4.1.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails4.1.gemfile
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
Rails 4.1 does not work with Ruby 2.4 or higher, so no need to run a
combination we know will fail.