### PR TITLE
Remove unneeded conditional for app_generators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    factory_bot_rails (4.10.0)
-      factory_bot (~> 4.10.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
 
 GEM
@@ -72,7 +72,7 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.1)
     execjs (2.7.0)
-    factory_bot (4.10.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     ffi (1.9.25)
     ffi (1.9.25-java)
@@ -168,4 +168,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/lib/factory_bot_rails/generator.rb
+++ b/lib/factory_bot_rails/generator.rb
@@ -5,11 +5,7 @@ require 'factory_bot_rails/generators/null_generator'
 module FactoryBotRails
   class Generator
     def initialize(config)
-      @generators = if config.respond_to?(:app_generators)
-                      config.app_generators
-                    else
-                      config.generators
-                    end
+      @generators = config.app_generators
     end
 
     def run
@@ -17,14 +13,12 @@ module FactoryBotRails
     end
 
     def generator
-      if factory_bot_disabled?
-        Generators::NullGenerator
+      return Generators::NullGenerator if factory_bot_disabled?
+
+      if test_framework == :rspec
+        Generators::RSpecGenerator
       else
-        if test_framework == :rspec
-          Generators::RSpecGenerator
-        else
-          Generators::NonRSpecGenerator
-        end
+        Generators::NonRSpecGenerator
       end
     end
 

--- a/lib/generators/factory_bot/model/model_generator.rb
+++ b/lib/generators/factory_bot/model/model_generator.rb
@@ -91,8 +91,7 @@ RUBY
       end
 
       def generators
-        config = FactoryBotRails::Railtie.config
-        config.respond_to?(:app_generators) ? config.app_generators : config.generators
+        FactoryBotRails::Railtie.config.app_generators
       end
     end
   end


### PR DESCRIPTION
Configuration#generators was deprecated in favor of
Configuration#app_generators back in Rails 3.1 (https://github.com/rails/rails/commit/04cbabb0a0206553d7b474ee7a191d19957048fe).
Since we started work on factory_bot_rails 5, which only supports Rails
4.2+, we no longer need the conditional.

I also updated the development Gemfile, since it was out of date,
and replaced a nested if/else with elsif.