### PR TITLE
Fix syntax error in documentation for `filename_proc` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For even more customization, use the `filename_proc` option:
 
 ```ruby
 config.generators do |g|
-  g.factory_bot filename_proc: -> { |table_name| "prefix_#{table_name}_suffix" }
+  g.factory_bot filename_proc: ->(table_name) { "prefix_#{table_name}_suffix" }
 end
 ```
 


### PR DESCRIPTION
Fix syntax error in the documentation for `filename_proc` option