### PR TITLE
Address todos generated by rubocop for files in the features/ directory.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,31 +50,17 @@ Layout/IndentationWidth:
   Exclude:
     - 'lib/generators/factory_bot/model/model_generator.rb'
 
-# Offense count: 7
-Lint/AmbiguousRegexpLiteral:
-  Exclude:
-    - 'features/step_definitions/appraisal.rb'
-    - 'features/step_definitions/rails_steps.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:
   Exclude:
     - 'Rakefile'
-    - 'features/support/env.rb'
 
 # Offense count: 2
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 40
-
-# Offense count: 2
-# Configuration parameters: Blacklist.
-# Blacklist: END, (?-mix:EO[A-Z]{1})
-Naming/HeredocDelimiterNaming:
-  Exclude:
-    - 'features/step_definitions/rails_steps.rb'
 
 # Offense count: 1
 Naming/MemoizedInstanceVariableName:
@@ -116,19 +102,12 @@ Style/HashSyntax:
     - 'gemfiles/rails5.1.gemfile'
     - 'gemfiles/rails5.2.gemfile'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/MultilineIfModifier:
-  Exclude:
-    - 'features/support/env.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 # Configuration parameters: PreferredDelimiters.
 Style/PercentLiteralDelimiters:
   Exclude:
     - 'factory_bot_rails.gemspec'
-    - 'features/step_definitions/rails_steps.rb'
 
 # Offense count: 84
 # Cop supports --auto-correct.
@@ -141,8 +120,6 @@ Style/StringLiterals:
     - 'Gemfile'
     - 'Rakefile'
     - 'factory_bot_rails.gemspec'
-    - 'features/step_definitions/rails_steps.rb'
-    - 'features/support/env.rb'
     - 'lib/factory_bot_rails.rb'
     - 'lib/factory_bot_rails/generator.rb'
     - 'lib/factory_bot_rails/generators/rspec_generator.rb'

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -1,41 +1,41 @@
 When /^I add "([^"]+)" from this project as a dependency$/ do |gem_name|
-  append_to_file('Gemfile', %{gem "#{gem_name}", :path => "#{PROJECT_ROOT}"\n})
+  append_to_file("Gemfile", %{gem "#{gem_name}", :path => "#{PROJECT_ROOT}"\n})
 end
 
 When /^I add "([^"]+)" as a dependency$/ do |gem_name|
-  append_to_file('Gemfile', %{gem "#{gem_name}"\n})
+  append_to_file("Gemfile", %{gem "#{gem_name}"\n})
 end
 
 When /^I print out "([^"]*)"$/ do |path|
   in_current_dir do
-    File.open(path, 'r') do |f|
+    File.open(path, "r") do |f|
       puts f.inspect
     end
   end
 end
 
 When /^I configure the factories as:$/ do |string|
-  append_to_file File.join('config', 'application.rb'), <<-END
+  append_to_file File.join("config", "application.rb"), <<-RUBY
 class Testapp::Application
   #{string}
 end
-  END
+  RUBY
 end
 
 When /^I configure the factories directory as "([^"]+)"$/ do |factory_dir|
-  append_to_file File.join('config', 'application.rb'), <<-END
+  append_to_file File.join("config", "application.rb"), <<-RUBY
 class Testapp::Application
   config.generators do |g|
     g.fixture_replacement :factory_bot, :dir => "#{factory_dir}"
   end
 end
-  END
+  RUBY
 end
 
 When /^I comment out gem "([^"]*)" from my Gemfile$/ do |gem_name|
   in_current_dir do
-    content = File.read('Gemfile')
-    File.open('Gemfile', 'w') do |f|
+    content = File.read("Gemfile")
+    File.open("Gemfile", "w") do |f|
       f.write content.sub(/gem ['"]#{gem_name}/, '#\1')
     end
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,21 +1,23 @@
-require 'aruba/cucumber'
+require "aruba/cucumber"
 
-PROJECT_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..', '..')).freeze
+PROJECT_ROOT = File.expand_path(File.join(File.dirname(__FILE__), "..", "..")).freeze
 
 Aruba.configure do |config|
   config.exit_timeout = Integer ENV.fetch("ARUBA_TIMEOUT") { 120 }
 end
 
-Aruba.configure do |config|
-  config.before_cmd do |cmd|
-    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+if RUBY_PLATFORM == "java"
+  Aruba.configure do |config|
+    config.before_cmd do |_|
+      set_env("JRUBY_OPTS", "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
 
-    java_options = ENV['JAVA_OPTS']
+      java_options = ENV["JAVA_OPTS"]
 
-    if 1.size == 4 # 4 for 32 bit java, 8 for 64 bit java.
-      set_env('JAVA_OPTS', "-d32 #{java_options}")
-    else
-      set_env('JAVA_OPTS', "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 #{java_options}")
+      if 1.size == 4 # 4 for 32 bit java, 8 for 64 bit java.
+        set_env("JAVA_OPTS", "-d32 #{java_options}")
+      else
+        set_env("JAVA_OPTS", "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 #{java_options}")
+      end
     end
   end
-end if RUBY_PLATFORM == 'java'
+end


### PR DESCRIPTION
This partially addresses [#239](https://github.com/thoughtbot/factory_bot_rails/issues/293) by deleting references to files in the `features/` directory from `.rubocop.yml` and fixing the subsequent warnings.