### PR TITLE
Address todos generated by rubocop for files in Rakefile and Appraisals.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,7 +61,6 @@ Lint/AmbiguousRegexpLiteral:
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:
   Exclude:
-    - 'Rakefile'
     - 'features/support/env.rb'
 
 # Offense count: 2
@@ -110,7 +109,6 @@ Style/EmptyMethod:
 # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
 Style/HashSyntax:
   Exclude:
-    - 'Rakefile'
     - 'gemfiles/rails4.2.gemfile'
     - 'gemfiles/rails5.0.gemfile'
     - 'gemfiles/rails5.1.gemfile'
@@ -137,9 +135,7 @@ Style/PercentLiteralDelimiters:
 Style/StringLiterals:
   EnforcedStyle: "double_quotes"
   Exclude:
-    - 'Appraisals'
     - 'Gemfile'
-    - 'Rakefile'
     - 'factory_bot_rails.gemspec'
     - 'features/step_definitions/rails_steps.rb'
     - 'features/support/env.rb'
@@ -185,10 +181,3 @@ Style/WordArray:
 # URISchemes: http, https
 Metrics/LineLength:
   Max: 133
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RegexpMatch:
-  Exclude:
-    - 'Rakefile'
-

--- a/Appraisals
+++ b/Appraisals
@@ -1,19 +1,19 @@
 # These are the versions of Rails we want to test against.
-appraise 'rails4.2' do
-  gem 'rails', '~> 4.2.0'
+appraise "rails4.2" do
+  gem "rails", "~> 4.2.0"
 end
 
-appraise 'rails5.0' do
-  gem 'activerecord', '~> 5.0.0'
-  gem 'railties', '~> 5.0.0'
+appraise "rails5.0" do
+  gem "activerecord", "~> 5.0.0"
+  gem "railties", "~> 5.0.0"
 end
 
-appraise 'rails5.1' do
-  gem 'activerecord', '~> 5.1.0'
-  gem 'railties', '~> 5.1.0'
+appraise "rails5.1" do
+  gem "activerecord", "~> 5.1.0"
+  gem "railties", "~> 5.1.0"
 end
 
-appraise 'rails5.2' do
-  gem 'activerecord', '~> 5.2.0'
-  gem 'railties', '~> 5.2.0'
+appraise "rails5.2" do
+  gem "activerecord", "~> 5.2.0"
+  gem "railties", "~> 5.2.0"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ RSpec::Core::RakeTask.new(:spec)
 require "appraisal"
 
 desc "Run the test suite"
-task :default do |_|
+task :default do
   if ENV["BUNDLE_GEMFILE"] =~ /gemfiles/
     exec "rake spec && rake cucumber"
   else
@@ -22,6 +22,6 @@ task :default do |_|
   end
 end
 
-task appraise: ["appraisal:install"] do |_|
+task appraise: ["appraisal:install"] do
   exec "rake appraisal"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,27 @@
-require 'bundler/setup'
-require 'cucumber/rake/task'
-require 'rspec/core/rake_task'
+require "bundler/setup"
+require "cucumber/rake/task"
+require "rspec/core/rake_task"
 
-Bundler::GemHelper.install_tasks name: 'factory_bot_rails'
+Bundler::GemHelper.install_tasks name: "factory_bot_rails"
 
 Cucumber::Rake::Task.new(:cucumber) do |t|
   t.fork = true
-  t.cucumber_opts = ['--format', (ENV['CUCUMBER_FORMAT'] || 'progress')]
+  t.cucumber_opts = ["--format", (ENV["CUCUMBER_FORMAT"] || "progress")]
 end
 
 RSpec::Core::RakeTask.new(:spec)
 
-require 'appraisal'
+require "appraisal"
 
-desc 'Run the test suite'
-task :default do |t|
-  if ENV['BUNDLE_GEMFILE'] =~ /gemfiles/
-    exec 'rake spec && rake cucumber'
+desc "Run the test suite"
+task :default do |_|
+  if ENV["BUNDLE_GEMFILE"] =~ /gemfiles/
+    exec "rake spec && rake cucumber"
   else
-    Rake::Task['appraise'].execute
+    Rake::Task["appraise"].execute
   end
 end
 
-task :appraise => ['appraisal:install'] do |t|
-  exec 'rake appraisal'
+task appraise: ["appraisal:install"] do |_|
+  exec "rake appraisal"
 end


### PR DESCRIPTION
This partially addresses [#239](https://github.com/thoughtbot/factory_bot_rails/issues/293) by deleting references to Rakefile and the Appraisals file from `.rubocop.yml` and fixing the subsequent warnings.