### PR TITLE
Address todos generated by rubocop for files in the lib/generators directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,13 +28,6 @@ Layout/IndentHeredoc:
     - 'lib/generators/factory_bot/model/model_generator.rb'
 
 # Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: Width, IgnoredPatterns.
-Layout/IndentationWidth:
-  Exclude:
-    - 'lib/generators/factory_bot/model/model_generator.rb'
-
-# Offense count: 2
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
   Max: 40
@@ -49,25 +42,6 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
-    - 'lib/generators/factory_bot/model/model_generator.rb'
-
-# Offense count: 84
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  EnforcedStyle: "double_quotes"
-  Exclude:
-    - 'lib/generators/factory_bot.rb'
-    - 'lib/generators/factory_bot/model/model_generator.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiteralsInInterpolation:
-  Exclude:
-    - 'lib/generators/factory_bot/model/model_generator.rb'
 
 # Offense count: 4
 # Cop supports --auto-correct.
@@ -76,7 +50,6 @@ Style/StringLiteralsInInterpolation:
 Style/TrailingCommaInArguments:
   Exclude:
     - 'spec/factory_bot_rails/definition_file_paths_spec.rb'
-    - 'lib/generators/factory_bot/model/model_generator.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,38 +27,6 @@ Layout/IndentHeredoc:
     - 'features/step_definitions/rails_steps.rb'
     - 'lib/generators/factory_bot/model/model_generator.rb'
 
-# Offense count: 2
-# Configuration parameters: CountComments, ExcludedMethods.
-Metrics/BlockLength:
-  Max: 40
-
-# Offense count: 1
-Naming/MemoizedInstanceVariableName:
-  Exclude:
-    - 'lib/generators/factory_bot.rb'
-
-# Offense count: 9
-Style/Documentation:
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArguments:
-  Exclude:
-    - 'spec/factory_bot_rails/definition_file_paths_spec.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  EnforcedStyle: percent
-  MinSize: 3
-
 # Offense count: 11
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/lib/generators/factory_bot.rb
+++ b/lib/generators/factory_bot.rb
@@ -1,10 +1,10 @@
-require 'rails/generators/named_base'
+require "rails/generators/named_base"
 
 module FactoryBot
   module Generators
     class Base < Rails::Generators::NamedBase #:nodoc:
       def self.source_root
-        @_factory_bot_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'factory_bot', generator_name, 'templates'))
+        @_factory_bot_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), "factory_bot", generator_name, "templates"))
       end
 
       def explicit_class_option

--- a/lib/generators/factory_bot.rb
+++ b/lib/generators/factory_bot.rb
@@ -4,7 +4,7 @@ module FactoryBot
   module Generators
     class Base < Rails::Generators::NamedBase #:nodoc:
       def self.source_root
-        @_factory_bot_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), "factory_bot", generator_name, "templates"))
+        @_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), "factory_bot", generator_name, "templates"))
       end
 
       def explicit_class_option

--- a/lib/generators/factory_bot.rb
+++ b/lib/generators/factory_bot.rb
@@ -4,7 +4,7 @@ module FactoryBot
   module Generators
     class Base < Rails::Generators::NamedBase #:nodoc:
       def self.source_root
-        @_source_root ||= File.expand_path(File.join(File.dirname(__FILE__), "factory_bot", generator_name, "templates"))
+        File.expand_path(File.join(File.dirname(__FILE__), "factory_bot", generator_name, "templates"))
       end
 
       def explicit_class_option

--- a/lib/generators/factory_bot/model/model_generator.rb
+++ b/lib/generators/factory_bot/model/model_generator.rb
@@ -1,5 +1,5 @@
-require 'generators/factory_bot'
-require 'factory_bot_rails'
+require "generators/factory_bot"
+require "factory_bot_rails"
 
 module FactoryBot
   module Generators
@@ -8,21 +8,21 @@ module FactoryBot
         :attributes,
         type: :array,
         default: [],
-        banner: "field:type field:type"
+        banner: "field:type field:type",
       )
 
       class_option(
         :dir,
         type: :string,
         default: "test/factories",
-        desc: "The directory or file root where factories belong"
+        desc: "The directory or file root where factories belong",
       )
 
       class_option(
         :suffix,
         type: :string,
         default: nil,
-        desc: "Suffix to add factory file"
+        desc: "Suffix to add factory file",
       )
 
       def create_fixture_file
@@ -43,7 +43,7 @@ module FactoryBot
         insert_into_file(
           factories_file,
           factory_definition,
-          after: "FactoryBot.define do\n"
+          after: "FactoryBot.define do\n",
         )
       end
 
@@ -53,19 +53,19 @@ module FactoryBot
       end
 
       def factory_definition
-<<-RUBY
+        <<-RUBY
   factory :#{singular_table_name}#{explicit_class_option} do
-#{factory_attributes.gsub(/^/, "    ")}
+#{factory_attributes.gsub(/^/, '    ')}
   end
-RUBY
+        RUBY
       end
 
       def single_file_factory_definition
-<<-RUBY
+        <<-RUBY
 FactoryBot.define do
 #{factory_definition.chomp}
 end
-RUBY
+        RUBY
       end
 
       def factory_attributes
@@ -78,7 +78,7 @@ RUBY
         if factory_bot_options[:filename_proc].present?
           factory_bot_options[:filename_proc].call(table_name)
         else
-          [table_name, filename_suffix].compact.join('_')
+          [table_name, filename_suffix].compact.join(" ")
         end
       end
 

--- a/lib/generators/factory_bot/model/model_generator.rb
+++ b/lib/generators/factory_bot/model/model_generator.rb
@@ -78,7 +78,7 @@ end
         if factory_bot_options[:filename_proc].present?
           factory_bot_options[:filename_proc].call(table_name)
         else
-          [table_name, filename_suffix].compact.join(" ")
+          [table_name, filename_suffix].compact.join("_")
         end
       end
 


### PR DESCRIPTION
This partially addresses [#239](https://github.com/thoughtbot/factory_bot_rails/issues/293) by deleting references to files in the `lib/generators` directory from `.rubocop.yml` and fixing the subsequent warnings.

One caveat: I did not address the `Naming/MemoizedInstanceVariableName` cop for lib/generators/factory_bot.rb in favor of honoring “Use a leading underscore when defining instance variables for memoization” in the [styleguide](https://github.com/thoughtbot/guides/tree/master/style/rubyhttps://github.com/thoughtbot/guides/tree/master/style/ruby)