### PR TITLE
Unclosed String literal in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ It is possible to use this setting to share factories from a gem:
 ```rb
 class MyEngine < ::Rails::Engine
   config.factory_bot.definition_file_paths =
-    File.expand_path('../factories, __FILE__) if defined?(FactoryBotRails)
+    File.expand_path('../factories', __FILE__) if defined?(FactoryBotRails)
 end
 ```
 


### PR DESCRIPTION
And so here's a fix.