### PR TITLE
Add newline between factories in same file

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -34,12 +34,18 @@ Feature:
       end
       """
     And I run `bundle exec rails generate model User name:string` with a clean environment
+    And I run `bundle exec rails generate model Robot name:string` with a clean environment
     Then the file "test/factories.rb" should contain exactly:
       """
       FactoryBot.define do
+        factory :robot do
+          name { "MyString" }
+        end
+
         factory :user do
           name { "MyString" }
         end
+
       end
       """
 
@@ -51,4 +57,4 @@ Feature:
       end
       """
     And I run `bundle exec rails generate model User name:string` with a clean environment
-    Then the file "test/factories.rb" should contain "factory :user do"
+    Then the file "test/factories/users.rb" should not contain "factory :user do"

--- a/lib/generators/factory_bot/model/model_generator.rb
+++ b/lib/generators/factory_bot/model/model_generator.rb
@@ -57,13 +57,14 @@ module FactoryBot
             factory :#{singular_table_name}#{explicit_class_option} do
           #{factory_attributes.gsub(/^/, '    ')}
             end
+
         RUBY
       end
 
       def single_file_factory_definition
         <<~RUBY
           FactoryBot.define do
-          #{factory_definition.chomp}
+          #{factory_definition.rstrip}
           end
         RUBY
       end


### PR DESCRIPTION
Fixes #305 

When generating factories in the same file (for example
spec/factories.rb), before this PR we didn't put newlines between the
factories. So if you generated a user factory, then a robot factory, you
would end up with something like this:

```rb
FactoryBot.define do
  factory :robot do
    name { "MyString" }
  end
  factory :user do
    name { "MyString" }
  end
end
```

With this PR, generating those factories will now look like:

```rb
FactoryBot.define do
  factory :robot do
    name { "MyString" }
  end

  factory :user do
    name { "MyString" }
  end

end
```

Note that the final newline is not ideal, but it will only be added when
generating the first factory, whereas the missing newline after
factories was happening every time we generated a new factory. So
with this PR we will only need to fix a whitespace style error once, rather
than N-1 times. We can could open another issue to fix the extra newline
at the end, but I think it may be more complicated than it sounds.

Co-authored-by: Nick Sanford <me@nicksanford.io>