### PR TITLE
Allow using custom template for the generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ config.generators do |g|
 end
 ```
 
+To override the [default factory template][], define your own template in
+`lib/templates/factory\_bot/models/factories.erb`. This template will have
+access to any methods available in `FactoryBot::Generators::ModelGenerator`.
+Note that factory\_bot\_rails will only use this custom template if you are
+generating each factory in a separate file; it will have no effect if you are
+generating all of your factories in `test/factories.rb` or `spec/factories.rb`.
+
+[default factory template]: https://github.com/thoughtbot/factory_bot_rails/tree/master/lib/generators/factory_bot/model/templates/factories.erb
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/features/generators.feature
+++ b/features/generators.feature
@@ -7,10 +7,10 @@ Feature:
     Given I successfully run `bundle exec rails new testapp`
     And I cd to "testapp"
     And I add "factory_bot_rails" from this project as a dependency
+    And I run `bundle install` with a clean environment
 
   Scenario: The factory_bot_rails generators create a factory file for each model if there is not a factories.rb file
-    When I run `bundle install` with a clean environment
-    And I run `bundle exec rails generate model User name:string age:integer` with a clean environment
+    When I run `bundle exec rails generate model User name:string age:integer` with a clean environment
     And I run `bundle exec rails generate model Namespaced::User name:string` with a clean environment
     Then the output should contain "test/factories/users.rb"
     And the output should contain "test/factories/namespaced_users.rb"
@@ -22,13 +22,11 @@ Feature:
           age { 1 }
         end
       end
-
       """
     And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, class: 'Namespaced::User' do"
 
   Scenario: The factory_bot_rails generators add a factory in the correct spot
-    When I run `bundle install` with a clean environment
-    And I write to "test/factories.rb" with:
+    When I write to "test/factories.rb" with:
       """
       FactoryBot.define do
       end
@@ -50,11 +48,21 @@ Feature:
       """
 
   Scenario: The factory_bot_rails generators does not create a factory file for each model if there is a factories.rb file in the test directory
-    When I run `bundle install` with a clean environment
-    And I write to "test/factories.rb" with:
+    When I write to "test/factories.rb" with:
       """
       FactoryBot.define do
       end
       """
     And I run `bundle exec rails generate model User name:string` with a clean environment
     Then the file "test/factories/users.rb" should not contain "factory :user do"
+
+  Scenario: The factory_bot_rails generators use a custom template
+    When I write to "lib/templates/factory_bot/model/factories.erb" with:
+      """
+      <%= "Custom factory definition" %>
+      """
+    And I run `bundle exec rails generate model User` with a clean environment
+    Then the file "test/factories/users.rb" should contain exactly:
+      """
+      Custom factory definition
+      """

--- a/lib/generators/factory_bot/model/model_generator.rb
+++ b/lib/generators/factory_bot/model/model_generator.rb
@@ -49,7 +49,7 @@ module FactoryBot
 
       def create_factory_file
         file = File.join(options[:dir], "#{filename}.rb")
-        create_file(file, single_file_factory_definition)
+        template "factories.erb", file
       end
 
       def factory_definition
@@ -58,14 +58,6 @@ module FactoryBot
           #{factory_attributes.gsub(/^/, '    ')}
             end
 
-        RUBY
-      end
-
-      def single_file_factory_definition
-        <<~RUBY
-          FactoryBot.define do
-          #{factory_definition.rstrip}
-          end
         RUBY
       end
 

--- a/lib/generators/factory_bot/model/templates/factories.erb
+++ b/lib/generators/factory_bot/model/templates/factories.erb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+<%= factory_definition.rstrip %>
+end


### PR DESCRIPTION
PR #135 introduced the ability to generate factories in one file, but it
also removed the ability to use custom templates for generating
factories. This PR adds back the ability to use custom templates when
generating factories in separate files. I doubt this was a heavily used
feature, but it has come up a few times and it I think supporting it
simplifies the generator.

Closes #147
Closes #148
Closes #193

PR #193 basically reverted #135, which is undesirable. thoughtbot
projects generally prefer putting all the factories in one file.

Co-authored-by: Nick Sanford <me@nicksanford.io>