### PR TITLE
Generate namespaced factories in a directory

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -13,7 +13,7 @@ Feature:
     When I run `bundle exec rails generate model User name:string age:integer` with a clean environment
     And I run `bundle exec rails generate model Namespaced::User name:string` with a clean environment
     Then the output should contain "test/factories/users.rb"
-    And the output should contain "test/factories/namespaced_users.rb"
+    And the output should contain "test/factories/namespaced/users.rb"
     And the file "test/factories/users.rb" should contain exactly:
       """
       FactoryBot.define do
@@ -23,7 +23,7 @@ Feature:
         end
       end
       """
-    And the file "test/factories/namespaced_users.rb" should contain "factory :namespaced_user, class: 'Namespaced::User' do"
+    And the file "test/factories/namespaced/users.rb" should contain "factory :namespaced_user, class: 'Namespaced::User' do"
 
   Scenario: The factory_bot_rails generators add a factory in the correct spot
     When I write to "test/factories.rb" with:

--- a/lib/generators/factory_bot/model/model_generator.rb
+++ b/lib/generators/factory_bot/model/model_generator.rb
@@ -71,7 +71,8 @@ module FactoryBot
         if factory_bot_options[:filename_proc].present?
           factory_bot_options[:filename_proc].call(table_name)
         else
-          [table_name, filename_suffix].compact.join("_")
+          name = File.join(class_path, plural_name)
+          [name, filename_suffix].compact.join("_")
         end
       end
 


### PR DESCRIPTION
Closes #231

When generating factories for namespaced models
(like `Admin::User`), we can follow the pattern used by the model and model
test generators of generating the file inside a directory matching the namespace.
With this commit we generate `test/factories/admin/user.rb` instead of
`test/factories/admin_user.rb`.