### PR TITLE
Use an older version of bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ env:
   - ARUBA_TIMEOUT=240
 before_install:
   - gem update --system
-  - gem update bundler
-  - gem cleanup bundler
+  - rvm @default,@global do gem uninstall bundler -v 2.0.1 -x
 cache: bundler
 rvm:
   - 2.3


### PR DESCRIPTION
Rails 4.2 requires bundler < 2.0, but on travis we are getting 2.0.1
There is probably a better way to do this so we don't have to update
this every time travis starts using a new version, but I am going to
merge this for now to unblock the release of 5.0.0.rc1