### PR TITLE
Only add exist paths to reloading target

### DIFF
--- a/lib/factory_bot_rails/definition_file_paths.rb
+++ b/lib/factory_bot_rails/definition_file_paths.rb
@@ -2,8 +2,6 @@
 
 module FactoryBotRails
   class DefinitionFilePaths
-    attr_reader :files, :directories
-
     def initialize(definition_file_paths)
       @files = []
       @directories = {}
@@ -12,6 +10,14 @@ module FactoryBotRails
         @files << "#{path}.rb"
         @directories[path.to_s] = [:rb]
       end
+    end
+
+    def directories
+      @directories.select { |path| Dir.exist?(path) }
+    end
+
+    def files
+      @files.select { |file| File.exist?(file) }
     end
   end
 end

--- a/spec/factory_bot_rails/definition_file_paths_spec.rb
+++ b/spec/factory_bot_rails/definition_file_paths_spec.rb
@@ -2,33 +2,32 @@
 
 describe FactoryBotRails::DefinitionFilePaths do
   describe "#files" do
-    it "returns a list of definition files" do
-      definition_file_paths = ["definition_path", "another_definition_path"]
+    it "returns a list of definition files that only exist" do
+      definition_file_paths = ["spec/fixtures/factories", "not_exist_directory"]
 
       files = described_class.new(definition_file_paths).files
 
-      expect(files).to eq ["definition_path.rb", "another_definition_path.rb"]
+      expect(files).to eq ["spec/fixtures/factories.rb"]
     end
   end
 
   describe "#directories" do
-    it "returns a hash of definition directories" do
-      definition_file_paths = ["definition_path", "another_definition_path"]
+    it "returns a hash of definition directories that only exist" do
+      definition_file_paths = ["spec/fixtures/factories", "not_exist_directory"]
 
       directories = described_class.new(definition_file_paths).directories
 
       expect(directories).to eq(
-        "definition_path" => [:rb],
-        "another_definition_path" => [:rb],
+        "spec/fixtures/factories" => [:rb],
       )
     end
 
     it "converts Pathname objects to strings" do
-      definition_file_paths = [Pathname.new("definition_path")]
+      definition_file_paths = [Pathname.new("spec/fixtures/factories")]
 
       directories = described_class.new(definition_file_paths).directories
 
-      expect(directories).to eq("definition_path" => [:rb])
+      expect(directories).to eq("spec/fixtures/factories" => [:rb])
     end
   end
 end


### PR DESCRIPTION
Currently, `factories`, `test/factories` and `spec/factories` are specified by default as reload watching paths.
In many applications, there are directories which do not exist (perhaps do not have` spec` if using minitest and do not have` spec` if using minitest).

In Rails 5 series, if specify a path that does not exist in`EventedFileUpdateChecker`, its parent is added to the watching path.
As a result, `node_modules` is also included in the watching path, and unexpectedly many directories and files are included in listen's watching targets. Also, if symlink is included in `node_modules`, it also causes warning of listen.

This issue is solved in Rails 6. However, since many applications use this gem in Rails 5 and below, it is good not to add directories that do not exist on the gem side.

Ref: https://github.com/rails/rails/issues/32700