### PR TITLE
Use compatible sqlite3 version in test application

### DIFF
--- a/features/fixture_replacement_config.feature
+++ b/features/fixture_replacement_config.feature
@@ -3,7 +3,7 @@ Feature:
   I would like the Factory Bot Rails gem to configure Factory Bot as the fixture replacement.
 
   Background:
-    Given I successfully run `bundle exec rails new testapp`
+    Given I successfully run `bundle exec rails new testapp -m ../../features/support/rails_template`
     And I cd to "testapp"
     And I add "factory_bot_rails" from this project as a dependency
 

--- a/features/generators.feature
+++ b/features/generators.feature
@@ -4,7 +4,7 @@ Feature:
   I would like to use factory_bot_rails generators.
 
   Background:
-    Given I successfully run `bundle exec rails new testapp`
+    Given I successfully run `bundle exec rails new testapp -m ../../features/support/rails_template`
     And I cd to "testapp"
     And I add "factory_bot_rails" from this project as a dependency
     And I run `bundle install` with a clean environment

--- a/features/load_definitions.feature
+++ b/features/load_definitions.feature
@@ -1,7 +1,7 @@
 Feature: automatically load factory definitions
 
   Background:
-    When I successfully run `bundle exec rails new testapp`
+    When I successfully run `bundle exec rails new testapp -m ../../features/support/rails_template`
     And I cd to "testapp"
     And I add "factory_bot_rails" from this project as a dependency
     And I add "test-unit" as a dependency

--- a/features/support/rails_template
+++ b/features/support/rails_template
@@ -1,0 +1,1 @@
+gsub_file "Gemfile", /^gem 'sqlite3'$/, 'gem "sqlite3", "~> 1.3.6"'


### PR DESCRIPTION
Currently, the `sqlite3` in `Gemfile` generated by `rails new` is not compatible with Rails.

To solve this issue, modified it to use compatible `sqlite3` using template.
Ref: https://github.com/rails/rails/issues/35161