### PR TITLE
Fix Markdown formatting

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,14 +8,13 @@
    and thus CI doesn't need to run,
    so you can add "[ci skip]" to the commit message.
 1. Tag the release: `git tag -s vVERSION`
-  - We recommend the [_quick guide on how to sign a release_] from git ready.
+    - We recommend the [_quick guide on how to sign a release_] from git ready.
 1. Push changes: `git push && git push --tags`
 1. Build and publish:
-  ```bash
-  gem build factory_bot_rails.gemspec
-  gem push factory_bot_rails-VERSION.gem
-  ```
-
+    ```bash
+    gem build factory_bot_rails.gemspec
+    gem push factory_bot_rails-VERSION.gem
+    ```
 1. Add a new GitHub release using the recent `NEWS.md` as the content. Sample
    URL: https://github.com/thoughtbot/factory_bot_rails/releases/new?tag=vVERSION
 1. Announce the new release,


### PR DESCRIPTION
The list was not enumerating when rendered, because the indentation was only two spaces, not four.