### PR TITLE
Always execute a reload when Rails triggers one (instead of just on u…

### DIFF
--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -22,10 +22,6 @@ module FactoryBotRails
       Reloader.new(app, config).run
     end
 
-    config.after_initialize do
-      FactoryBot.find_definitions
-    end
-
     private
 
     def definition_file_paths

--- a/lib/factory_bot_rails/reloader.rb
+++ b/lib/factory_bot_rails/reloader.rb
@@ -31,7 +31,7 @@ module FactoryBotRails
 
     def register_reloader(reloader)
       config.to_prepare do
-        reloader.execute_if_updated
+        reloader.execute
       end
 
       app.reloaders << reloader

--- a/spec/factory_bot_rails/railtie_spec.rb
+++ b/spec/factory_bot_rails/railtie_spec.rb
@@ -9,7 +9,7 @@ describe FactoryBotRails::Railtie do
         touch("factories.rb")
         reload_rails!
 
-        expect(FactoryBot).to have_received(:reload)
+        expect(FactoryBot).to have_received(:reload).at_least(1).times
       end
     end
 
@@ -20,17 +20,17 @@ describe FactoryBotRails::Railtie do
         touch("factories/definitions.rb")
         reload_rails!
 
-        expect(FactoryBot).to have_received(:reload)
+        expect(FactoryBot).to have_received(:reload).at_least(1).times
       end
     end
 
     context "when the factory definitions have NOT been updated" do
-      it "does NOT reload the factory definitions" do
+      it "reloads the factory definitions" do
         allow(FactoryBot).to receive(:reload)
 
         reload_rails!
 
-        expect(FactoryBot).not_to have_received(:reload)
+        expect(FactoryBot).to have_received(:reload).at_least(1).times
       end
     end
 


### PR DESCRIPTION
…pdate) to prevent doubly-defined constants errors in factories when using Spring

- https://github.com/thoughtbot/factory_bot_rails/issues/323