### PR TITLE
Test more realistic scenario for 3rd-party engine

### DIFF
--- a/features/load_definitions.feature
+++ b/features/load_definitions.feature
@@ -138,16 +138,27 @@ Feature: automatically load factory definitions
         end
       end
       """
+    When I write to "test/factories.rb" with:
+      """
+      FactoryBot.define do
+        factory :user do
+          name { "Frank" }
+        end
+      end
+      """
     When I write to "test/unit/user_test.rb" with:
       """
       require 'test_helper'
 
       class UserTest < ActiveSupport::TestCase
         test "use factory of some_railtie" do
-          user = FactoryBot.create(:factory_from_some_railtie)
-          assert_equal 'Artem', user.name
+          railtie_user = FactoryBot.create(:factory_from_some_railtie)
+          assert_equal 'Artem', railtie_user.name
+
+          user = FactoryBot.create(:user)
+          assert_equal 'Frank', user.name
         end
       end
       """
     When I run `bundle exec rake test` with a clean environment
-    Then the output should contain "1 assertions, 0 failures, 0 errors"
+    Then the output should contain "2 assertions, 0 failures, 0 errors"


### PR DESCRIPTION
With factory_bot 5 we changed the official way to include factory_bot
definitions in an engine from using an initializer to using the
`config.factory_bot.definition_file_paths` configuration.
We left these tests with the initializer around because we wanted to
avoid breaking existing engines.

With #331 if none of the paths in
`config.factory_bot.definition_file_paths` exist we won't load any
factory definitions at all.

Before this PR this test was failing with #311 because none of the paths
in `config.factory_bot.definition_file_paths` existed, and so the
definition file in the engine never got loaded.

I am changing this test because there scenario is unlike. If somebody is
using factory_bot definitions from an engine, they will most likely have
their own factory definitions as well, defined in one of the
`config.factory_bot.definition_file_paths`.

If it turns out somebody is using factory_bot definitions from an engine
without also using definitions in their own project, there are a couple
of workarounds:

- Add an empty factory file (e.g. test/factories.rb)
- Manually call `FactoryBot.reload`
- Update the engine to use the official `config.factory_bot.definition_file_paths` instead of an initializer