### PR TITLE
Add back loading definitions in after_initialize

### DIFF
--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -22,6 +22,10 @@ module FactoryBotRails
       Reloader.new(app, config).run
     end
 
+    config.after_initialize do
+      FactoryBot.reload
+    end
+
     private
 
     def definition_file_paths


### PR DESCRIPTION
We removed the call to `FactoryBot.load_definitions` in the
`after_initialize` hook in dcfc9f6 because the other changes in that
commit were causing us to sometimes call `FactoryBot.load_definitions`
after `FactoryBot.reload`.

We could have changed `FactoryBot.load_definitions` to
`FactoryBot.reload`, which is what this PR does, but it didn't seem
necessary at the time since all the tests were still passing.

We fixed a problem in 9b83f48 that was causing us to watch the root
directory of the project. This fix caused a test failure, but I ended up
changing the test in 2b7bca0 because it seemed like an unlikely
scenario.

This PR adds back the original test case. Although I do think it
unlikely, I would rather not risk making a breaking change in the next
patch release.