### PR TITLE
Fix definition_file_paths setting for Rails engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,14 @@ This will cause factory\_bot\_rails to automatically load factories in
 It is possible to use this setting to share factories from a gem:
 
 ```rb
+begin
+  require 'factory_bot_rails'
+rescue LoadError
+end
+
 class MyEngine < ::Rails::Engine
   config.factory_bot.definition_file_paths =
-    File.expand_path('../factories', __FILE__) if defined?(FactoryBotRails)
+    [File.expand_path('../factories', __FILE__)] if defined?(FactoryBotRails)
 end
 ```
 


### PR DESCRIPTION
### 1. Add `require`

Even if both Rails engine gem and factory_bot_rails gem are written on Gemfile, `defined?(FactoryBotRails)` returns false because it depends on the order on Gemfile.

### 2. `definition_file_paths` is an Array

I'm not sure it should be `+=` or `=` though, anyway, it must be an Array.