### PR TITLE
Add active_storage, action_mailer bootsnap and sass-rails gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   - ARUBA_TIMEOUT=240
 before_install:
   - gem update --system
-  - rvm @default,@global do gem uninstall bundler -v 2.0.1 -x
+  - rvm @default,@global do gem uninstall bundler -v 2.0.2 -x
 cache: bundler
 rvm:
   - 2.3

--- a/Appraisals
+++ b/Appraisals
@@ -8,16 +8,24 @@ appraise "rails5.0" do
   gem "activerecord", "~> 5.0.7"
   gem "railties", "~> 5.0.7"
   gem "sqlite3", "~> 1.3.6"
+  gem "actionmailer", "~> 5.0.7"
+  gem "sass-rails"
 end
 
 appraise "rails5.1" do
   gem "activerecord", "~> 5.1.7"
   gem "railties", "~> 5.1.7"
+  gem "actionmailer", "~> 5.1.7"
+  gem "sass-rails"
 end
 
 appraise "rails5.2" do
   gem "activerecord", "~> 5.2.3"
   gem "railties", "~> 5.2.3"
+  gem "actionmailer", "~> 5.2.3"
+  gem "bootsnap"
+  gem "activestorage", "~> 5.2.3"
+  gem "sass-rails"
 end
 
 appraise "rails6.0" do

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -19,5 +19,7 @@ gem "sqlite3", "~> 1.3.6"
 gem "rubocop", "0.54", require: false
 gem "activerecord", "~> 5.0.7"
 gem "railties", "~> 5.0.7"
+gem "actionmailer", "~> 5.0.7"
+gem "sass-rails"
 
 gemspec name: "factory_bot_rails", path: "../"

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -19,5 +19,7 @@ gem "sqlite3", platforms: :ruby
 gem "rubocop", "0.54", require: false
 gem "activerecord", "~> 5.1.7"
 gem "railties", "~> 5.1.7"
+gem "actionmailer", "~> 5.1.7"
+gem "sass-rails"
 
 gemspec name: "factory_bot_rails", path: "../"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -19,5 +19,9 @@ gem "sqlite3", platforms: :ruby
 gem "rubocop", "0.54", require: false
 gem "activerecord", "~> 5.2.3"
 gem "railties", "~> 5.2.3"
+gem "actionmailer", "~> 5.2.3"
+gem "bootsnap"
+gem "activestorage", "~> 5.2.3"
+gem "sass-rails"
 
 gemspec name: "factory_bot_rails", path: "../"


### PR DESCRIPTION
This pull request adds active_storage, action_mailer bootsnap and sass-rails gems to address these errors:

* Address  undefined method `active_storage'

https://travis-ci.org/yahonda/factory_bot_rails/jobs/567544663#L802

```
+/home/travis/.rvm/gems/ruby-2.4.6/gems/railties-5.2.3/lib/rails/railtie/configuration.rb:97:in `method_missing': undefined method `active_storage' for #<Rails::Application::Configuration:0x000000000417d758> (NoMethodError)
```

* Address undefined_method `action_mailer'

https://travis-ci.org/thoughtbot/factory_bot_rails/jobs/548726224#L1657

```ruby
+/home/travis/.rvm/gems/ruby-2.4.6/gems/railties-5.0.7.2/lib/rails/railtie/configuration.rb:95:in `method_missing': undefined method `action_mailer' for #<Rails::Application::Configuration:0x0000000002807418> (NoMethodError)
```

* Address `undefined method `assets'`

https://travis-ci.org/yahonda/factory_bot_rails/jobs/567544663

```
+/home/travis/.rvm/gems/ruby-2.6.3/gems/railties-5.0.7.2/lib/rails/railtie/configuration.rb:95:in `method_missing': undefined method `assets' for #<Rails::Application::Configuration:0x000000000337e5f8>
+Did you mean?  asset_host (NoMethodError)
```

* Address `can not load such file -- bootsnap/setup (LoadError)`

https://travis-ci.org/thoughtbot/factory_bot_rails/jobs/548726226#L1703

```ruby
+/home/travis/build/thoughtbot/factory_bot_rails/tmp/aruba/testapp/config/boot.rb:4:in `require': cannot load such file -- bootsnap/setup (LoadError)
```

This pull request address `Bundler could not find compatible versions for gem "bundler":` for Rails 4.2 by uninstalling bundler 2.0.2