### PR TITLE
Fix rubocop offenses in generated files

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -18,7 +18,7 @@ Feature:
       """
       FactoryBot.define do
         factory :user do
-          name { "MyString" }
+          name { 'MyString' }
           age { 1 }
         end
       end
@@ -37,11 +37,11 @@ Feature:
       """
       FactoryBot.define do
         factory :robot do
-          name { "MyString" }
+          name { 'MyString' }
         end
 
         factory :user do
-          name { "MyString" }
+          name { 'MyString' }
         end
 
       end

--- a/features/generators.feature
+++ b/features/generators.feature
@@ -16,6 +16,8 @@ Feature:
     And the output should contain "test/factories/namespaced/users.rb"
     And the file "test/factories/users.rb" should contain exactly:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :user do
           name { 'MyString' }
@@ -28,6 +30,8 @@ Feature:
   Scenario: The factory_bot_rails generators add a factory in the correct spot
     When I write to "test/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
       end
       """
@@ -35,6 +39,8 @@ Feature:
     And I run `bundle exec rails generate model Robot name:string` with a clean environment
     Then the file "test/factories.rb" should contain exactly:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :robot do
           name { 'MyString' }
@@ -50,6 +56,8 @@ Feature:
   Scenario: The factory_bot_rails generators does not create a factory file for each model if there is a factories.rb file in the test directory
     When I write to "test/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
       end
       """

--- a/features/load_definitions.feature
+++ b/features/load_definitions.feature
@@ -35,7 +35,7 @@ Feature: automatically load factory definitions
       """
       FactoryBot.define do
         factory :user do
-          name { "Frank" }
+          name { 'Frank' }
         end
       end
       """
@@ -62,7 +62,7 @@ Feature: automatically load factory definitions
       """
       FactoryBot.define do
         factory :user do
-          name { "Frank" }
+          name { 'Frank' }
         end
       end
       """
@@ -179,7 +179,7 @@ Feature: automatically load factory definitions
       """
       FactoryBot.define do
         factory :user do
-          name { "Frank" }
+          name { 'Frank' }
         end
       end
       """

--- a/features/load_definitions.feature
+++ b/features/load_definitions.feature
@@ -33,6 +33,8 @@ Feature: automatically load factory definitions
   Scenario: generate a Rails application and use factory definitions
     When I write to "test/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :user do
           name { 'Frank' }
@@ -60,6 +62,8 @@ Feature: automatically load factory definitions
       """
     When I write to "custom_factories_path.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :user do
           name { 'Frank' }
@@ -95,6 +99,8 @@ Feature: automatically load factory definitions
       """
     When I write to "lib/some_railtie/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :factory_from_some_railtie, class: 'User' do
           name { 'Artem' }
@@ -132,6 +138,8 @@ Feature: automatically load factory definitions
       """
     When I write to "lib/some_railtie/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :factory_from_some_railtie, class: 'User' do
           name { 'Artem' }
@@ -169,6 +177,8 @@ Feature: automatically load factory definitions
       """
     When I write to "lib/some_railtie/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :factory_from_some_railtie, class: 'User' do
           name { 'Artem' }
@@ -177,6 +187,8 @@ Feature: automatically load factory definitions
       """
     When I write to "test/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :user do
           name { 'Frank' }

--- a/features/reloading.feature
+++ b/features/reloading.feature
@@ -34,6 +34,8 @@ Feature:
       """
     And I write to "test/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :author, class: User do
           name { 'Frank' }
@@ -84,6 +86,8 @@ Scenario: Initializing the reloader with I18n support
       """
     And I write to "test/factories.rb" with:
       """
+      # frozen_string_literal: true
+
       FactoryBot.define do
         factory :user do
           User::TRANSLATION

--- a/features/reloading.feature
+++ b/features/reloading.feature
@@ -36,7 +36,7 @@ Feature:
       """
       FactoryBot.define do
         factory :author, class: User do
-          name { "Frank" }
+          name { 'Frank' }
         end
       end
       """

--- a/lib/generators/factory_bot/model/model_generator.rb
+++ b/lib/generators/factory_bot/model/model_generator.rb
@@ -63,7 +63,13 @@ module FactoryBot
 
       def factory_attributes
         attributes.map do |attribute|
-          "#{attribute.name} { #{attribute.default.inspect} }"
+          attribute_value = if attribute.default.is_a?(String)
+                              "'#{attribute.default}'"
+                            else
+                              attribute.default.inspect
+                            end
+
+          "#{attribute.name} { #{attribute_value} }"
         end.join("\n")
       end
 

--- a/lib/generators/factory_bot/model/templates/factories.erb
+++ b/lib/generators/factory_bot/model/templates/factories.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
 <%= factory_definition.rstrip %>
 end


### PR DESCRIPTION
When scaffolding a new model the generator generates the factory with rubocop offenses (using default rubocop configuration for rails).

Fixed offenses:
- Style/StringLiterals
- Style/FrozenStringLiteralComment

