### PR TITLE
Test against ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ env:
   - ARUBA_TIMEOUT=240
 cache: bundler
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
 branches:
   only:
@@ -23,7 +23,5 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
-    - rvm: 2.3
-      gemfile: gemfiles/rails6.0.gemfile
     - rvm: 2.4
       gemfile: gemfiles/rails6.0.gemfile


### PR DESCRIPTION
And drop support for EOL 2.3 (holding off on dropping 2.4 since the
website hasn't yet been updated to show that it is EOL)

https://www.ruby-lang.org/en/downloads/branches/