### PR TITLE
Add issue templates [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+<!-- By contributing to this project, you agree to abide by the thoughtbot Code
+of Conduct: https://thoughtbot.com/open-source-code-of-conduct -->
+
+### Description
+
+<!-- A clear and concise description of what the bug is. -->
+
+<!-- NOTE: factory_bot_rails includes automatic factory definition loading and
+rails generators. Bugs not related to those two features likely belong on the
+factory_bot repository instead of this one. Don't worry if you are unsure; if
+the issue is in the wrong place we will transfer it over. -->
+
+### Reproduction Steps
+
+<!-- Steps for others to reproduce the bug. Be as specific as possible. Ideally
+provide a link to a sample Rails application that demonstrates the problem. -->
+
+### Expected behavior
+
+<!-- What you expected to happen. -->
+
+### Actual behavior
+
+<!-- What happened instead. -->
+
+### System configuration
+**factory_bot_rails version**:  
+**factory_bot version**:  
+**rails version**:  
+**ruby version**:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature'
+assignees: ''
+
+---
+
+<!-- By contributing to this project, you agree to abide by the thoughtbot Code
+of Conduct: https://thoughtbot.com/open-source-code-of-conduct -->
+
+### Problem this feature will solve
+
+<!-- A clear and concise description of what the problem is. Ex. When doing
+[...] I find it difficult to [...] -->
+
+<!-- NOTE: factory_bot_rails includes automatic factory definition loading and
+rails generators. Features requests unrelated to those likely belong on the
+factory_bot repository instead of this one. Don't worry if you are unsure; if
+the issue is in the wrong place we will transfer it over. -->
+
+### Desired solution
+
+<!-- The feature or change that would solve the problem -->
+
+## Alternatives considered
+
+<!-- Any alternative solutions or features you've considered. -->
+
+## Additional context
+
+<!-- Add any other context about this feature request. -->


### PR DESCRIPTION
This commit adds issue templates for bug reports and feature requests,
hopefully making issue triage a bit easier. This was created using
GitHub's [issue template UI].

[issue template UI]: https://github.com/thoughtbot/factory_bot_rails/issues/templates/edit