### PR TITLE
Remove branch for rails 4.2 reloader

### DIFF
--- a/spec/factory_bot_rails/railtie_spec.rb
+++ b/spec/factory_bot_rails/railtie_spec.rb
@@ -39,14 +39,7 @@ describe FactoryBotRails::Railtie do
     end
 
     def reload_rails!
-      if defined? ActiveSupport::Reloader
-        Rails.application.reloader.reload!
-      else
-        # For Rails 4
-        ActionDispatch::Reloader.cleanup!
-        ActionDispatch::Reloader.prepare!
-      end
-
+      Rails.application.reloader.reload!
       wait_for_rails_to_reload
     end
 


### PR DESCRIPTION
We are no longer testing against Rails 4.2, so we no longer need to
branch for the Rails 4.2 style reloader