### PR TITLE
Add missing test coverage for using spring

### DIFF
--- a/features/reloading.feature
+++ b/features/reloading.feature
@@ -1,22 +1,11 @@
-Feature:
-  When using factory_bot_rails together with Spring
-  I want changes to my application to trigger the factory_bot_rails reloader
-  So that factory_bot_rails doesn't hold onto stale class references
-
-  Scenario: Editing a model without editing the factory
+Feature: automatically reloading factory_bot definitions
+  Background:
     When I create a new rails application
     And I add "factory_bot_rails" from this project as a dependency
     And I run `bundle install` with a clean environment
     And I write to "db/migrate/1_create_users.rb" with:
       """
-      migration_class =
-        if ActiveRecord::Migration.respond_to?(:[])
-          ActiveRecord::Migration[4.2]
-        else
-          ActiveRecord::Migration
-        end
-
-      class CreateUsers < migration_class
+      class CreateUsers < ActiveRecord::Migration[5.0]
         def self.up
           create_table :users do |t|
             t.string :name
@@ -25,7 +14,12 @@ Feature:
       end
       """
     And I run `bundle exec rake db:migrate` with a clean environment
-    And I write to "app/models/user.rb" with:
+
+  Scenario: When using factory_bot_rails together with Spring
+    I want changes to my application to trigger the factory_bot_rails reloader
+    So that factory_bot_rails doesn't hold onto stale class references
+
+    When I write to "app/models/user.rb" with:
       """
       class User < ActiveRecord::Base
       end
@@ -43,7 +37,7 @@ Feature:
       require 'test_helper'
 
       class UserTest < ActiveSupport::TestCase
-        test "use factory" do
+        test "user factory" do
           author = FactoryBot.create(:author)
 
           assert_equal author.class.object_id, User.object_id
@@ -62,27 +56,28 @@ Feature:
     Then the output should contain "1 runs, 1 assertions"
     And the output should not contain "Failure:"
 
-Scenario: Initializing the reloader with I18n support
-    When I create a new rails application
-    And I add "factory_bot_rails" from this project as a dependency
-    And I run `bundle install` with a clean environment
-    And I run `bundle exec rake db:migrate` with a clean environment
-    And I write to "app/models/user.rb" with:
+  Scenario: When using factory_bot_rails together with Spring
+    I want changes to my factory_bot definitions to trigger a reload
+    So that I can use my updated definitions without stopping spring
+
+    When I write to "app/models/user.rb" with:
       """
-      class User
-        TRANSLATION = I18n.translate("translation_key")
+      class User < ActiveRecord::Base
       end
-      """
-    And I write to "config/locales/en.yml" with:
-      """
-        en:
-          translation_key: "translation_value"
       """
     And I write to "test/factories.rb" with:
       """
+      # Empty definition file to be picked up by the file watcher
+
+      """
+    And I run `bundle binstubs bundler rake spring --force` with a clean environment
+    And I run `bin/spring binstub --all` with a clean environment
+    And I run `bin/rake test` with Spring enabled
+    And I append to "test/factories.rb" with:
+      """
       FactoryBot.define do
-        factory :user do
-          User::TRANSLATION
+        factory :author, class: User do
+          name { "Frank" }
         end
       end
       """
@@ -91,13 +86,50 @@ Scenario: Initializing the reloader with I18n support
       require 'test_helper'
 
       class UserTest < ActiveSupport::TestCase
-        test "use factory" do
-          user = FactoryBot.build(:user)
+        test "user factory" do
+          author = FactoryBot.create(:author)
 
-          assert_equal "translation_value", User::TRANSLATION
+          assert_equal author.class.object_id, User.object_id
         end
       end
       """
-    And I run `bundle exec rake test` with a clean environment
+    And I run `bin/rake test` with Spring enabled
+    And I run `spring stop` with a clean environment
     Then the output should contain "1 runs, 1 assertions"
     And the output should not contain "Failure:"
+
+  Scenario: Initializing the reloader with I18n support
+      When I write to "app/models/user.rb" with:
+        """
+        class User
+          TRANSLATION = I18n.translate("translation_key")
+        end
+        """
+      And I write to "config/locales/en.yml" with:
+        """
+          en:
+            translation_key: "translation_value"
+        """
+      And I write to "test/factories.rb" with:
+        """
+        FactoryBot.define do
+          factory :user do
+            User::TRANSLATION
+          end
+        end
+        """
+      And I write to "test/unit/user_test.rb" with:
+        """
+        require 'test_helper'
+
+        class UserTest < ActiveSupport::TestCase
+          test "eser factory" do
+            user = FactoryBot.build(:user)
+
+            assert_equal "translation_value", User::TRANSLATION
+          end
+        end
+        """
+      And I run `bundle exec rake test` with a clean environment
+      Then the output should contain "1 runs, 1 assertions"
+      And the output should not contain "Failure:"


### PR DESCRIPTION
Previously our tests were not covering the line where we [add the
factory_bot_rails reloader to the list of Rails reloaders][reloaders
push].
[Spring checks this reloaders list][spring] to decide whether it
needs to reload the rails application. Without adding our reloader to
this list changes to factory_bot definitions would only get picked up
by running `spring stop` (or disabling spring entirely).

This test will ensure we don't accidentally break this interaction
between factory_bot_rails and spring. I verified that this test fails
when deleting the relevant line (no other tests in the suite fail).

While adding this test this commit pulls out a bit of shared background for
the tests in this file, and also removes some Rails 4.2 logic that isn't
necessary anymore since we won't support Rails 4.2 for factory_bot_rails
6.

[reloaders push]: https://github.com/thoughtbot/factory_bot_rails/blob/master/lib/factory_bot_rails/reloader.rb#L42
[spring]: https://github.com/rails/spring/blob/647b8c31356f31a22c3d783aae824d41ab579a57/lib/spring/application.rb#L165