### PR TITLE
Bump listen to ~> 3.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -31,7 +31,7 @@ end
 
 appraise "rails6.0" do
   gem "byebug"
-  gem "listen", ">= 3.0.5", "< 3.2"
+  gem "listen", "~> 3.2"
   gem "puma", "~> 4.1"
   gem "rails", "~> 6.0.2", ">= 6.0.2.2"
   gem "spring"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -9,7 +9,7 @@ gem "rake"
 gem "rspec-rails"
 gem "rubocop", "0.54", require: false
 gem "byebug"
-gem "listen", ">= 3.0.5", "< 3.2"
+gem "listen", "~> 3.2"
 gem "puma", "~> 4.1"
 gem "rails", "~> 6.0.2", ">= 6.0.2.2"
 gem "spring"


### PR DESCRIPTION
This matches a change made in a recent version of Rails 6.0.

Without this commit, CI fails because the wrong version of the gem gets
installed.