### PR TITLE
Update NEWS.md to mention v5.2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@ there might not be any notable changes in new versions of this project.
   reloader after application initialization
 * Removed: support for EOL versions of Ruby (2.3, 2.4) and Rails (4.2)
 
+## 5.2.0 (April 26, 2020)
+
+* Changed: factory\_bot dependency to ~> 5.2.0
+
 ## 5.1.1 (September 24, 2019)
 
 * Fixed: Ensure definitions do not load before I18n is initialized


### PR DESCRIPTION
It looks like it was omitted by mistake.