### PR TITLE
Add projections.json for Dispatch.vim support

### DIFF
--- a/lib/rails/projections.json
+++ b/lib/rails/projections.json
@@ -1,0 +1,26 @@
+{
+  "spec/factories/*.rb": {
+    "alternate": "app/models/{singular}.rb",
+    "collection": "model",
+    "command": "factory",
+    "template": [
+      "FactoryBot.define do",
+      "  factory :{singular} do",
+      "  end",
+      "end"
+    ],
+    "test": "spec/models/{singular}_spec.rb"
+  },
+  "test/factories/*.rb": {
+    "alternate": "app/models/{singular}.rb",
+    "collection": "model",
+    "command": "factory",
+    "template": [
+      "FactoryBot.define do",
+      "  factory :{singular} do",
+      "  end",
+      "end"
+    ],
+    "test": "test/models/{singular}_test.rb"
+  }
+}


### PR DESCRIPTION
Rails.vim allows gems to provide their own projections compatible with
Dispatch.vim by placing them at lib/rails/projections.json. This
configuration allows:

- :A from a factory to alternate to the test file
- :Efactory (and :{S,V,T}factory) to navigate to or create a new factory
- highlights FactoryBot macros as Ruby macros
- Sets up :{E,S,V,T}unittest for factories => model specs

To use this, you'll need Rails.vim, Bundler.vim, and Dispatch.vim
plugins.

See `:help rails-projections` or [the file on
GitHub](https://github.com/tpope/vim-rails/blob/6bc0c7826d68f8c44c8347a3012aa79ade4f0a22/doc/rails.txt#L611-L726)
for more clarity on what specifically each config key is doing.

Inspired and updated from [@henrik's
Gist](https://gist.github.com/henrik/5676109#file-config-projections-json-L10-L15)