### PR TITLE
Upgrade bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,4 +176,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.1.4
+   2.4.12


### PR DESCRIPTION
This gets rid of a pesky warning:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
``