### PR TITLE
Address standard TODO

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,0 @@
-# Auto generated files with errors to ignore.
-# Remove from this list as you refactor files.
----
-ignore:
-- lib/factory_bot_rails/generators/null_generator.rb:
-  - Style/RedundantInitialize

--- a/lib/factory_bot_rails/generators/null_generator.rb
+++ b/lib/factory_bot_rails/generators/null_generator.rb
@@ -1,7 +1,7 @@
 module FactoryBotRails
   module Generators
     class NullGenerator
-      def initialize(generators)
+      def initialize(*)
       end
 
       def run


### PR DESCRIPTION
I looked more into the `RedundantInitialize` cop and it shows splat arguments as acceptable. That seems good enough here—it's not strictly the same arity, but that doesn't really matter for this null object.

I also upgraded all the dev dependencies in https://github.com/thoughtbot/factory_bot_rails/commit/b6463a937da8e6129cbb34d7faa7f0a5b9c71b23 so we get a version of RuboCop that [marks this particular cop as unsafe](https://github.com/rubocop/rubocop/commit/f3b201bf48cfc0249a7676c3461dfd5934ba758d), and a version of standard that [separates autocorrection of safe and unsafe cops](https://github.com/standardrb/standard/pull/545). That should hopefully prevent us from incorrectly fixing unsafe cops in the future.

cc @mathieujobin 