### PR TITLE
Cancel duplicate workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ on:
   - push
   - pull_request
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}


### PR DESCRIPTION
This avoids duplicate runs for both push and PR.

https://docs.github.com/en/actions/using-jobs/using-concurrency