### PR TITLE
Expand matrix for more recent versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails: ["7.0"]
-        ruby: [3.2]
+        rails: ["7.0", "6.1"]
+        ruby: ["3.2", "3.1"]
         include:
-          - rails: "6.1"
-            ruby: "3.1"
           - rails: "6.1"
             ruby: "3.0"
           - rails: "6.1"


### PR DESCRIPTION
This adds some extra coverage for combinations of newer versions of Ruby and Rails.

A number of the other versions are EOL or soon-to-be EOL, and we'll probably drop them anyway whenever we do another major release of factory_bot_rails, so being thorough there probably doesn't matter as much.