### PR TITLE
Wrap ActiveRecord configuration into initializer

### DIFF
--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -21,13 +21,15 @@ module FactoryBotRails
       FactoryBot.definition_file_paths = definition_file_paths
     end
 
-    ActiveSupport.on_load :active_record do
-      config = Rails.configuration.factory_bot
+    initializer "factory_bot.reject_primary_key_attributes" do
+      ActiveSupport.on_load :active_record do
+        config = Rails.configuration.factory_bot
 
-      if config.reject_primary_key_attributes
-        require "factory_bot_rails/factory_validator/active_record_validator"
+        if config.reject_primary_key_attributes
+          require "factory_bot_rails/factory_validator/active_record_validator"
 
-        config.validator.add_validator FactoryValidator::ActiveRecordValidator.new
+          config.validator.add_validator FactoryValidator::ActiveRecordValidator.new
+        end
       end
     end
 


### PR DESCRIPTION
`Rails.application` is not available when the railties are collected, so we move the ActiveRecord configuration into the initializer phase.

```
NoMethodError: undefined method `config' for nil:NilClass (NoMethodError)
      application.config
                 ^^^^^^^
/project/app/vendor/bundle/ruby/3.2.0/gems/railties-7.0.8/lib/rails.rb:47:in `configuration'
/project/app/vendor/bundle/ruby/3.2.0/gems/factory_bot_rails-6.4.0/lib/factory_bot_rails/railtie.rb:25:in `block in <class:Railtie>'
```