### PR TITLE
adding config to point to the changelog file

### DIFF
--- a/factory_bot_rails.gemspec
+++ b/factory_bot_rails.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
                   "factory_bot and rails 5.0 or newer"
 
   s.files = Dir["lib/**/*"] + %w[CONTRIBUTING.md LICENSE NEWS.md README.md]
+  s.metadata["changelog_uri"] = "https://github.com/thoughtbot/factory_bot_rails/blob/main/NEWS.md"
   s.require_paths = ["lib"]
   s.executables = []
   s.license = "MIT"


### PR DESCRIPTION
Rubygems.org does not show the changelog in its UI, because this gem does not follow the expected convention, and is missing the correct config. 


This PR explicitly lists the location of the file `NEWS.md` as the file with the Changelog.


e.g.:

![Screenshot 2023-11-20 at 11 36 46](https://github.com/thoughtbot/factory_bot_rails/assets/22553/93360205-26da-4984-b872-b67ac865c739)

An alternative solution would be to rename `NEWS.md` to `CHANGELOG.md`


