### PR TITLE
Change from `on_load :active_record` to `on_load :after_initialize` to ensure the Rails  configuration is available

### DIFF
--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -21,7 +21,7 @@ module FactoryBotRails
       FactoryBot.definition_file_paths = definition_file_paths
     end
 
-    ActiveSupport.on_load :active_record do
+    ActiveSupport.on_load :after_initialize do
       config = Rails.configuration.factory_bot
 
       if config.reject_primary_key_attributes


### PR DESCRIPTION
Otherwise one can run into this error:
```
  gems/railties-7.1.2/lib/rails.rb:51:in `configuration': undefined method `config' for nil:NilClass (NoMethodError)

      application.config
                 ^^^^^^^
  from gems/factory_bot_rails-6.4.0/lib/factory_bot_rails/railtie.rb:28:in `block in <class:Railtie>'
```