### PR TITLE
Fix/rails 7.1.2 compatibility

### DIFF
--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -21,13 +21,14 @@ module FactoryBotRails
       FactoryBot.definition_file_paths = definition_file_paths
     end
 
-    ActiveSupport.on_load :active_record do
-      config = Rails.configuration.factory_bot
+    initializer "factory_bot.active_record" do
+      ActiveSupport.on_load(:active_record) do
+        fb_config = Rails.application.config.factory_bot
 
-      if config.reject_primary_key_attributes
-        require "factory_bot_rails/factory_validator/active_record_validator"
-
-        config.validator.add_validator FactoryValidator::ActiveRecordValidator.new
+        if fb_config.reject_primary_key_attributes
+          require "factory_bot_rails/factory_validator/active_record_validator"
+          fb_config.validator.add_validator FactoryBotRails::FactoryValidator::ActiveRecordValidator.new
+        end
       end
     end
 


### PR DESCRIPTION
### Description

After upgrading to Rails 7.1.2, our application encounters a `NoMethodError` when attempting to access `config` on a `nil` object within `factory_bot_rails`. This issue is reproduced when the application is booting and seems to be related to the `factory_bot_rails` Railtie initialization process.

### Environment

- Rails Version: 7.1.2
- Ruby Version: 3.2.2
- FactoryBotRails Version: 6.4.0

### Error Output

```ruby
/usr/local/bundle/gems/railties-7.1.2/lib/rails.rb:51:in configuration': undefined method config' for nil:NilClass (NoMethodError)
```

### Steps to Reproduce

1. Upgrade a Rails application to version 7.1.2.
2. Use `factory_bot_rails` gem version 6.4.0.
3. Boot the application.

### Expected Behavior

The application should boot without errors, and `factory_bot_rails` should correctly integrate with the Rails application configuration.

### Actual Behavior

The application fails to boot, raising a `NoMethodError` related to `config`.

### Proposed Fix

The changes proposed in PR [8205851](https://github.com/thoughtbot/factory_bot_rails/pull/432/commits/8205851fabc026968d82f9fbd50b7ae9f2b5b1e1) seem to address the issue by ensuring that `config` is accessed in a way that is compatible with Rails 7.1.2's initialization process, I was not aware of the PR until now 😅 . It modifies the Railtie to defer the loading of `factory_bot_rails` until `active_record` is fully loaded, avoiding the `NoMethodError`.

I have applied the changes from the PR locally and confirmed that it resolves the error. This PR would be valuable for others who may face the same issue upon upgrading.

### Additional Information

If there is any additional information or testing required, please let me know. I am willing to assist in any way to get this issue resolved.