### PR TITLE
Fix the missing class in the AR validator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
-    sqlite3 (1.6.2)
+    sqlite3 (1.6.8)
       mini_portile2 (~> 2.8.0)
     standard (1.27.0)
       language_server-protocol (~> 3.17.0.2)

--- a/lib/factory_bot_rails/factory_validator/active_record_validator.rb
+++ b/lib/factory_bot_rails/factory_validator/active_record_validator.rb
@@ -3,8 +3,12 @@ module FactoryBotRails
     class ActiveRecordValidator
       def validate!(payload)
         attributes, for_class = payload.values_at(:attributes, :class)
+
+        # The class should be there, but we need an hotfix for https://github.com/thoughtbot/factory_bot_rails/issues/431
+        return unless for_class && for_class < ActiveRecord::Base
+
         attributes.each do |attribute|
-          if for_class < ActiveRecord::Base && for_class.primary_key == attribute.name.to_s
+          if for_class.primary_key == attribute.name.to_s
             raise FactoryBot::AttributeDefinitionError, <<~ERROR
               Attribute generates #{for_class.primary_key.inspect} primary key for #{for_class.name}"
 

--- a/spec/factory_bot_rails/factory_validator/active_record_validator_spec.rb
+++ b/spec/factory_bot_rails/factory_validator/active_record_validator_spec.rb
@@ -19,6 +19,18 @@ describe FactoryBotRails::FactoryValidator do
         expect { FactoryBot.create(:article) }
           .to raise_error(FactoryBot::AttributeDefinitionError)
       end
+
+      it "See https://github.com/thoughtbot/factory_bot_rails/issues/431" do
+        define_model "Article", an_id: :integer
+
+        FactoryBot.define do
+          factory :article do
+            an_id { 1 }
+          end
+        end
+
+        FactoryBot.create(:article)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #431

Not completely sure what's going on, except skipping the validation if there's no class. This is meant to be a temporary hot fix to save people from downgrading to 6.2. Will surely require further investigation.