### PR TITLE
Bump actions/checkout to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails }}.gemfile
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
Your CI is using a very outdated version of [actions/checkout](https://github.com/actions/checkout) 😄 

With this PR I have bumped that version to the latest stable one - [v4](https://github.com/actions/checkout/releases/tag/v4.0.0)