### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ column named `id` as its primary key.
 For example, defining an `id` attribute with `add_attribute(:id)`, `id { ... }`,
 or `sequence(:id)` will raise a `FactoryBot::AttributeDefinitionError`.
 
-You can disable this behavior by adding the following to `config/application.rb`
-or the appropriate environment configuration in `config/environments`:
+You can disable this behavior by adding the following to the appropriate environment configuration in `config/environments`
+e.g. `config/environments/test.rb`:
 
 ```ruby
 config.factory_bot.reject_primary_key_attributes = false


### PR DESCRIPTION
I removed `config/application.rb` from the file where the configuration is written.

https://github.com/thoughtbot/factory_bot_rails/blob/main/README.md?plain=1#L33-L35

As noted above, since this gem is not for production use, I thought it appropriate to place it in config/environments/test.rb. Writing the configuration in config/application.rb would cause the application to crash.