### PR TITLE
Allow specific factories to skip primary key definition checks

### DIFF
--- a/lib/factory_bot_rails/factory_validator/active_record_validator.rb
+++ b/lib/factory_bot_rails/factory_validator/active_record_validator.rb
@@ -2,9 +2,17 @@ module FactoryBotRails
   class FactoryValidator
     class ActiveRecordValidator
       def validate!(payload)
-        attributes, for_class = payload.values_at(:attributes, :class)
+        attributes, for_class, factory_name = payload.values_at(:attributes, :class, :name)
+
+        return if !(for_class && for_class < ActiveRecord::Base)
+
+        factory = FactoryBot::Internal.factory_by_name(factory_name)
+        if (factory.options[:config] || {} )[:allow_primary_key_definitions] == true
+          return
+        end
+
         attributes.each do |attribute|
-          if for_class < ActiveRecord::Base && for_class.primary_key == attribute.name.to_s
+          if for_class.primary_key == attribute.name.to_s
             raise FactoryBot::AttributeDefinitionError, <<~ERROR
               Attribute generates #{for_class.primary_key.inspect} primary key for #{for_class.name}"
 

--- a/spec/factory_bot_rails/factory_validator/active_record_validator_spec.rb
+++ b/spec/factory_bot_rails/factory_validator/active_record_validator_spec.rb
@@ -19,6 +19,44 @@ describe FactoryBotRails::FactoryValidator do
         expect { FactoryBot.create(:article) }
           .to raise_error(FactoryBot::AttributeDefinitionError)
       end
+
+
+      context "when factory is configured to allow primary key definitions" do
+        # NOTE: Modifying Factory here is only a proof of concept
+        class FactoryBot::Factory
+          attr_reader :options
+
+          def initialize(name, options = {})
+            assert_valid_options(options)
+            @name = name.respond_to?(:to_sym) ? name.to_sym : name.to_s.underscore.to_sym
+            @parent = options[:parent]
+            @aliases = options[:aliases] || []
+            @class_name = options[:class]
+            @definition = FactoryBot::Definition.new(@name, options[:traits] || [])
+            @compiled = false
+
+            @options = options # <-- Addition
+          end
+
+          def assert_valid_options(options)
+            options.assert_valid_keys(:class, :parent, :aliases, :traits, :config)
+          end
+        end
+
+        it "does not raise an error for a sequence generating its primary key" do
+          define_model "Warehouse", an_id: :integer do
+            self.primary_key = :an_id
+          end
+
+          FactoryBot.define do
+            factory :warehouse, config: { allow_primary_key_definitions: true } do
+              sequence(:an_id)
+            end
+          end
+
+          expect { FactoryBot.create(:warehouse) }.not_to raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Note: This PR is only a proof of concept idea due to monkey-patching `FactoryBot::Factory`.

## Problem

A new default in factory_bot_rails is to raise errors when a factory is defining a primary key. There are occasionally needs to assign a `ActiveRecord` model's primary key explicitly in a factory (see examples in #438). We don't want to entirely skip that additional check for every factory by disabling `reject_primary_key_attributes` for all factories.

## Possible Solution

Add a per factory configuration to skip the check for specific factories.

```ruby
FactoryBot.define do
  factory :warehouse, config: { allow_primary_key_definitions: true } do
    sequence(:id)
  end
end
```