### PR TITLE
Call dynamic-readme reusable workflow

### DIFF
--- a/.github/workflows/dynamic-readme.yml
+++ b/.github/workflows/dynamic-readme.yml
@@ -1,0 +1,17 @@
+name: update-templates
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-templates:
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+    uses: thoughtbot/templates/.github/workflows/dynamic-readme.yaml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ community](https://github.com/thoughtbot/factory_bot_rails/graphs/contributors).
 
 ## License
 
-factory_bot_rails is Copyright © 2008-2020 Joe Ferris and thoughtbot. It is free
+factory_bot_rails is Copyright © 2008-2024 Joe Ferris and thoughtbot. It is free
 software, and may be redistributed under the terms specified in the
 [LICENSE](LICENSE) file.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ community](https://github.com/thoughtbot/factory_bot_rails/graphs/contributors).
 
 ## License
 
-factory_bot_rails is Copyright © 2008-2024 Joe Ferris and thoughtbot. It is free
+factory_bot_rails is Copyright © 2008 Joe Ferris and thoughtbot. It is free
 software, and may be redistributed under the terms specified in the
 [LICENSE](LICENSE) file.
 

--- a/README.md
+++ b/README.md
@@ -165,16 +165,8 @@ factory_bot_rails is Copyright © 2008-2020 Joe Ferris and thoughtbot. It is fre
 software, and may be redistributed under the terms specified in the
 [LICENSE](LICENSE) file.
 
-## About thoughtbot
-
-![thoughtbot](https://thoughtbot.com/brand_assets/93:44.svg)
-
-factory_bot_rails is maintained and funded by thoughtbot, inc.
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
-
-We are passionate about open source software.
-See [our other projects][community].
-We are [available for hire][hire].
+<!-- START /templates/footer.md -->
+<!-- END /templates/footer.md -->
 
 [fb]: https://github.com/thoughtbot/factory_bot
 [grade]: https://codeclimate.com/github/thoughtbot/factory_bot_rails


### PR DESCRIPTION
We want to have a way to edit our README footer at one place and have the changes from there be propagated to our repos.

By adding this snippet in the README, we call this reusable workflow: https://github.com/thoughtbot/templates/blob/main/.github/workflows/dynamic-readme.yaml that renders and updates the README footer dynamically.