### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,15 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+# Global rule:
+*           

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Global rule:
-*           
+* @sarahraqueld @smaboshe @minaslater


### PR DESCRIPTION
This commit adds a `CODEOWNERS` file to the to define individuals and teams who are responsible for the project.

Ref:
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners