### PR TITLE
Ignore Project IDX workspace customisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 *.swp
 .bundle
-gemfiles/*.lock
+.idx
+.rubocop-https*
 coverage
+factory_bot_rails-*.gem
 factory_girl_rails-*.gem
+gemfiles/*.lock
 pkg
 rdoc
 test.db
 tmp
-.rubocop-https*
-factory_bot_rails-*.gem


### PR DESCRIPTION
When using Google Project IDX, it sets up a local customisations folder (`.idx`). This commit ignores that folder.

This commit also sorts the Git ignore file to make it easier to scan.

Ref:
- https://idx.dev/
- https://developers.google.com/idx/guides/customize-idx-env