### PR TITLE
Update factory_bot_rails.gemspec

### DIFF
--- a/factory_bot_rails.gemspec
+++ b/factory_bot_rails.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
   s.executables = []
   s.license = "MIT"
 
+  s.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
+
   s.add_runtime_dependency("factory_bot", "~> 6.4")
   s.add_runtime_dependency("railties", ">= 5.0.0")
 


### PR DESCRIPTION
I am currently in the process of upgrading from Ruby 2.6 to Ruby 3.0. Initially, I didn't find any restrictions on updating my current factory_bot_rails version to the latest one. Unfortunately, this turned out to be incorrect. The latest version of factory_bot_rails requires factory_bot v6.4, which requires Ruby 3, causing my update to fail.

```
SyntaxError: /root/project/vendor/bundle/ruby/2.6.0/gems/factory_bot-6.4.5/lib/factory_bot/evaluator.rb:38: syntax error, unexpected ...
...method_missing(method_name, ...)
```

So, adding the `required_ruby_version` might help to prevent the misconception.

References:
  - https://github.com/thoughtbot/factory_bot/issues/1614
  - https://github.com/thoughtbot/factory_bot/commit/36bd06583ffb5fd752862413fdd3c0affd1775a6
  - https://github.com/thoughtbot/factory_bot/pull/1622/files