### PR TITLE
Fix standardrb violations

### DIFF
--- a/spec/support/macros/define_constant.rb
+++ b/spec/support/macros/define_constant.rb
@@ -7,8 +7,8 @@ module DefineConstantMacros
     const
   end
 
-  def define_model(name, columns = {}, &block)
-    model = define_class(name, ActiveRecord::Base, &block)
+  def define_model(name, columns = {}, &)
+    model = define_class(name, ActiveRecord::Base, &)
     create_table(model.table_name) do |table|
       columns.each do |column_name, type|
         table.column column_name, type
@@ -17,12 +17,12 @@ module DefineConstantMacros
     model
   end
 
-  def create_table(table_name, &block)
+  def create_table(table_name, &)
     connection = ActiveRecord::Base.connection
 
     begin
       connection.execute("DROP TABLE IF EXISTS #{table_name}")
-      connection.create_table(table_name, &block)
+      connection.create_table(table_name, &)
       created_tables << table_name
       connection
     rescue Exception => e # rubocop:disable Lint/RescueException


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/factory_bot_rails/issues/474

### Problem

Standard is failing: 

```standard: Use Ruby Standard Style (https://github.com/standardrb/standard)
spec/support/macros/define_constant.rb:10:40: Style/ArgumentsForwarding: Use anonymous block arguments forwarding (&).
spec/support/macros/define_constant.rb:11:52: Style/ArgumentsForwarding: Use anonymous block arguments forwarding (&).
spec/support/macros/define_constant.rb:20:32: Style/ArgumentsForwarding: Use anonymous block arguments forwarding (&).
spec/support/macros/define_constant.rb:25:43: Style/ArgumentsForwarding: Use anonymous block arguments forwarding (&).
```

Running `standardrb --fix` changes `&block` to `&`, however, this only works for ruby >= 3.2.

Since we still support Ruby 3.0, this change introduces these errors: 

```
SyntaxError:

  /home/runner/work/factory_bot_rails/factory_bot_rails/spec/support/macros/define_constant.rb:10: syntax error, unexpected ')', expecting local variable or method
  ...ne_model(name, columns = {}, &)
  ...                              ^
``` 