### PR TITLE
Ignore Standard Style/ArgumentsForwarding violations temporarily

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,0 +1,6 @@
+# Auto generated files with errors to ignore.
+# Remove from this list as you refactor files.
+---
+ignore:
+- spec/support/macros/define_constant.rb:
+  - Style/ArgumentsForwarding


### PR DESCRIPTION
The CI is failing due to a few Standard violations. Fixing them is not trivial, so ignoring in the meantime and adding them to a standard-todo list will help us visualize when the CI is actually broken. 

We'll work on fixing the violations in a follow-up PR. 