### PR TITLE
Release 6.4.4 [ci skip]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    factory_bot_rails (6.4.3)
-      factory_bot (~> 6.4)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
       railties (>= 5.0.0)
 
 GEM

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ there might not be any notable changes in new versions of this project.
 
 # NEWS
 
+## 6.4.4 (October 25, 2024)
+
+* Changed: Bump Factory Bot 6.5.0
+
 ## 6.4.3 (December 29, 2023)
 
 * Changed: allow sequence definitions for ActiveRecord primary keys (Mike

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,22 +2,22 @@
 
 1. Update the version in the gemspec (and the factory\_bot version, if necessary)
    and run `bundle install`
-1. Update `NEWS.md` to reflect the changes since last release.
-1. Commit changes.
+2. Update `NEWS.md` to reflect the changes since last release.
+3. Commit changes.
    There shouldn't be code changes,
    and thus CI doesn't need to run,
    so you can add "[ci skip]" to the commit message.
-1. Tag the release: `git tag -s vVERSION`
+4. Tag the release: `git tag -s vVERSION`
     - We recommend the [_quick guide on how to sign a release_] from git ready.
-1. Push changes: `git push && git push --tags`
-1. Build and publish:
+5. Push changes: `git push && git push --tags`
+6. Build and publish:
     ```bash
     gem build factory_bot_rails.gemspec
     gem push factory_bot_rails-VERSION.gem
     ```
-1. Add a new GitHub release using the recent `NEWS.md` as the content. Sample
+7. Add a new GitHub release using the recent `NEWS.md` as the content. Sample
    URL: https://github.com/thoughtbot/factory_bot_rails/releases/new?tag=vVERSION
-1. Announce the new release,
+8. Announce the new release,
    making sure to say "thank you" to the contributors
    who helped shape this version!
 

--- a/factory_bot_rails.gemspec
+++ b/factory_bot_rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "factory_bot_rails"
-  s.version = "6.4.3"
+  s.version = "6.4.4"
   s.authors = ["Joe Ferris"]
   s.email = "jferris@thoughtbot.com"
   s.homepage = "https://github.com/thoughtbot/factory_bot_rails"
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = []
   s.license = "MIT"
 
-  s.add_runtime_dependency("factory_bot", "~> 6.4")
+  s.add_runtime_dependency("factory_bot", "~> 6.5")
   s.add_runtime_dependency("railties", ">= 5.0.0")
 
   s.add_development_dependency("sqlite3")


### PR DESCRIPTION
## What's Changed
* Update CI to run Ruby 3.3 by @aberkakis in https://github.com/thoughtbot/factory_bot_rails/pull/464
* Ignore Standard Style/ArgumentsForwarding violations temporarily by @sarahraqueld in https://github.com/thoughtbot/factory_bot_rails/pull/489
* Bump standard from 1.32.1 to 1.40.0 by @dependabot in https://github.com/thoughtbot/factory_bot_rails/pull/487
* Bump rspec-rails from 6.1.0 to 6.1.4 by @dependabot in https://github.com/thoughtbot/factory_bot_rails/pull/490
* Bump factory_bot from 6.4.0 to 6.5.0 by @dependabot in https://github.com/thoughtbot/factory_bot_rails/pull/492
* Bump rake from 13.1.0 to 13.2.1 by @dependabot in https://github.com/thoughtbot/factory_bot_rails/pull/491
* Update Bundler to v2.5.21 by @smaboshe in https://github.com/thoughtbot/factory_bot_rails/pull/499
* Update Bundler to v2.5.22 by @smaboshe in https://github.com/thoughtbot/factory_bot_rails/pull/500

## New Contributors
* @stefannibrasil made their first contribution in https://github.com/thoughtbot/factory_bot_rails/pull/463
* @aberkakis made their first contribution in https://github.com/thoughtbot/factory_bot_rails/pull/464
* @smaboshe made their first contribution in https://github.com/thoughtbot/factory_bot_rails/pull/469
* @sarahraqueld made their first contribution in https://github.com/thoughtbot/factory_bot_rails/pull/481

**Full Changelog**: https://github.com/thoughtbot/factory_bot_rails/compare/v6.4.3...v6.4.4