### PR TITLE
Drop support for Ruby 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         rails: ["7.1", "7.0", "6.1"]
-        ruby: ["3.3", "3.2", "3.1", "3.0"]
+        ruby: ["3.3", "3.2", "3.1"]
         exclude:
           - ruby: "3.1"
             rails: "7.1"


### PR DESCRIPTION
According to [Ruby lang page](https://www.ruby-lang.org/en/downloads/branches/), Ruby 3.0 reached EOL on April 2024.

Supporting Ruby 3.0 is preventing the project from implementing standardrb most recent version, since we need to add an special case for syntax introduced in 3.2.

See #482 and #474 



