### PR TITLE
Activate linter in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,16 @@ jobs:
         run: bundle install
       - name: Run test
         run: bundle exec rake
+
+  standard:
+    name: Run standard
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+      - name: Setup project
+        run: bundle install
+      - name: Run test
+        run: bundle exec rake standard

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -1,6 +1,0 @@
-# Auto generated files with errors to ignore.
-# Remove from this list as you refactor files.
----
-ignore:
-- spec/support/macros/define_constant.rb:
-  - Style/ArgumentsForwarding


### PR DESCRIPTION
Dropping support for Ruby version 3.0 #507 that enables removal of violations of linting #482 the linter should be activated in CI. Workflow follows job from [factory_bot](https://github.com/thoughtbot/factory_bot/blob/main/.github/workflows/build.yml#L54-L65).