### PR TITLE
Add missing required Ruby version to gemspec

### DIFF
--- a/factory_bot_rails.gemspec
+++ b/factory_bot_rails.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"] + %w[CONTRIBUTING.md LICENSE NEWS.md README.md]
   s.metadata["changelog_uri"] = "https://github.com/thoughtbot/factory_bot_rails/blob/main/NEWS.md"
   s.require_paths = ["lib"]
+  s.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
   s.executables = []
   s.license = "MIT"
 


### PR DESCRIPTION
fixes #456

`required_ruby_version` is an optional property in specification though [recommended by Rubygems guide](https://guides.rubygems.org/specification-reference/). The change requests follows specification of [factory_bot](https://github.com/thoughtbot/factory_bot/blob/main/factory_bot.gemspec#L18).