### PR TITLE
Support Rails 8 authentication generator

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -90,3 +90,19 @@ Feature:
     And I run `bundle exec rails generate model User name:string age:integer` with a clean environment
     Then the output should not contain "test/factories/users.rb"
     And the output should contain "test/fixtures/users.yml"
+
+  Scenario: The factory_bot_rails authentication generator, coupled with rspec-rails, creates a user factory file
+    When I add "rspec-rails" with options `github: "rspec/rspec-rails", branch: "main"` as a dependency
+    And I run `bundle install --verbose` with a clean environment
+    Then the output should contain "rspec-rails"
+    And I run `bundle exec rails generate authentication` with a clean environment
+    Then the output should contain "test/factories/users.rb"
+    And the file "test/factories/users.rb" should contain exactly:
+      """
+      FactoryBot.define do
+        factory :user do
+          email_address { "john@example.com" }
+          password_digest { "MyString" }
+        end
+      end
+      """

--- a/features/step_definitions/rails_steps.rb
+++ b/features/step_definitions/rails_steps.rb
@@ -28,6 +28,10 @@ When(/^I add "([^"]+)" as a dependency$/) do |gem_name|
   append_to_file("Gemfile", %(gem "#{gem_name}"\n))
 end
 
+When(/^I add "([^"]+)" with options `(.+)` as a dependency$/) do |gem_name, options|
+  append_to_file("Gemfile", %(gem "#{gem_name}", #{options}\n))
+end
+
 When(/^I print out "([^"]*)"$/) do |path|
   in_current_dir do
     File.open(path, "r") do |f|

--- a/lib/generators/factory_bot/authentication/authentication_generator.rb
+++ b/lib/generators/factory_bot/authentication/authentication_generator.rb
@@ -1,0 +1,12 @@
+require "generators/factory_bot"
+require "factory_bot_rails"
+
+module FactoryBot
+  module Generators
+    class AuthenticationGenerator < Base
+      def create_fixture_file
+        template "users.rb", "test/factories/users.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/factory_bot/authentication/templates/users.rb
+++ b/lib/generators/factory_bot/authentication/templates/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email_address { "john@example.com" }
+    password_digest { "MyString" }
+  end
+end


### PR DESCRIPTION
Follow-up to https://github.com/rspec/rspec-rails/pull/2811.

## Problem

When running `bin/rails generate authentication` for a Rails 8 app that has the `rspec-rails` gem, generation ends with the following error: `error    factory_bot [not found]`.

This is because `rspec-rails`' `AuthenticationGenerator` contains `hook_for :fixture_replacement`, which calls `factory_bot_rails`, but it errors out since `factory_bot_rails` does not have an authentication generator.

## Solution

Add authentication generator that creates a user factory with the `email_address` and `password_digest` fields. These fields come from the Rails [authentication generator](https://github.com/rails/rails/blob/d5be42897e09850ffbd31394ea9f805b9af055d5/railties/lib/rails/generators/rails/authentication/authentication_generator.rb#L51).