### PR TITLE
Add option to lazy load factory definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ class MyEngine < ::Rails::Engine
 end
 ```
 
+If your application has a large number of factories, you may want to enable
+lazy loading to speed up boot time:
+
+```rb
+config.factory_bot.lazy_load_definitions = true
+```
+
+With lazy loading of definitions enabled, `FactoryBot.factories` will appear
+empty after booting the application. All factory definitions will be loaded
+when any factory is first accessed by name.
+
 You can also disable automatic factory definition loading entirely by
 using an empty array:
 

--- a/features/load_definitions.feature
+++ b/features/load_definitions.feature
@@ -197,3 +197,36 @@ Feature: automatically load factory definitions
       """
     When I run `bundle exec rake test` with a clean environment
     Then the output should contain "2 assertions, 0 failures, 0 errors"
+
+  Scenario: use lazy loading of factory definitions
+    When I configure the factories as:
+      """
+      config.factory_bot.lazy_load_definitions = true
+      """
+    When I write to "test/factories.rb" with:
+      """
+      FactoryBot.define do
+        factory :user do
+          name { "Frank" }
+        end
+      end
+      """
+    When I write to "test/unit/user_test.rb" with:
+      """
+      require 'test_helper'
+
+      class UserTest < ActiveSupport::TestCase
+        test "use lazy loaded factory" do
+          assert FactoryBot.factories.none?
+          refute FactoryBot.factories.registered?(:user)
+
+          user = FactoryBot.create(:user)
+          assert_equal 'Frank', user.name
+
+          assert FactoryBot.factories.any?
+          assert FactoryBot.factories.registered?(:user)
+        end
+      end
+      """
+    When I run `bundle exec rake test` with a clean environment
+    Then the output should contain "5 assertions, 0 failures, 0 errors"

--- a/lib/factory_bot_rails/lazy_registry_find.rb
+++ b/lib/factory_bot_rails/lazy_registry_find.rb
@@ -1,0 +1,10 @@
+require "factory_bot/registry"
+
+module FactoryBotRails
+  module LazyRegistryFind
+    def find(*)
+      FactoryBot.find_definitions unless FactoryBot.factories.any?
+      super
+    end
+  end
+end

--- a/lib/factory_bot_rails/railtie.rb
+++ b/lib/factory_bot_rails/railtie.rb
@@ -10,6 +10,7 @@ module FactoryBotRails
   class Railtie < Rails::Railtie
     config.factory_bot = ActiveSupport::OrderedOptions.new
     config.factory_bot.definition_file_paths = FactoryBot.definition_file_paths
+    config.factory_bot.lazy_load_definitions = false
     config.factory_bot.validator = FactoryBotRails::FactoryValidator.new
 
     initializer "factory_bot.set_fixture_replacement" do
@@ -21,7 +22,13 @@ module FactoryBotRails
     end
 
     config.after_initialize do |app|
-      FactoryBot.find_definitions
+      if app.config.factory_bot.lazy_load_definitions && !app.config.eager_load
+        require "factory_bot_rails/lazy_registry_find"
+        FactoryBot::Registry.prepend FactoryBotRails::LazyRegistryFind
+      else
+        FactoryBot.find_definitions
+      end
+
       Reloader.new(app).run
       app.config.factory_bot.validator.run
     end


### PR DESCRIPTION
Loading factory definitions can sometimes have a noticeable impact on Rails boot time: For example, in a large app I work on `FactoryBot.find_definitions` takes an average of 0.3s to load 274 factories. An option to lazy load them would avoid this overhead when factories are not needed.

The new `lazy_load_definitions` option is disabled by default for compatibility reasons, but all tests pass for both `factory_bot` and `factory_bot_rails` when enabled. The railtie will also continue to load all factory definitions at boot if `config.eager_load` is enabled in the application.