### PR TITLE
Limit `push` builds to the `main` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build
 on:
-  - push
-  - pull_request
+  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Commits to a Pull Request branch have been triggering a build twice. That is happening because a `push` to a pull request is both a `push` and a `pull_request` activity.

<img width="825" alt="image" src="https://github.com/user-attachments/assets/a4f6f242-a1bd-416e-99e5-ed831555837c" />

This commit fixes this issue by limiting the `push` trigger to the `main` branch, ensuring that merged Pull Requests will run linting and tests on the main branch, and that any Pull Request activity will also trigger a build.