### PR TITLE
Update gemspec with supported Rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    factory_bot_rails (6.5.0)
+    factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
-      railties (>= 5.0.0)
+      railties (>= 6.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -93,8 +93,8 @@ GEM
       bigdecimal
     cucumber-gherkin (27.0.0)
       cucumber-messages (>= 19.1.4, < 23)
-    cucumber-html-formatter (21.8.0)
-      cucumber-messages (> 19, < 27)
+    cucumber-html-formatter (21.9.0)
+      cucumber-messages (> 19, < 28)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.2)
     date (3.4.1)
@@ -116,7 +116,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jar-dependencies (0.5.3)
+    jar-dependencies (0.5.4)
     json (2.9.1)
     json (2.9.1-java)
     language_server-protocol (3.17.0.4)
@@ -137,7 +137,7 @@ GEM
     nokogiri (1.18.2-java)
       racc (~> 1.4)
     parallel (1.26.3)
-    parser (3.3.7.0)
+    parser (3.3.7.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.2)
@@ -176,12 +176,12 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.11.0)
+    rdoc (6.12.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -189,7 +189,7 @@ GEM
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-rails (7.1.0)
+    rspec-rails (7.1.1)
       actionpack (>= 7.0)
       activesupport (>= 7.0)
       railties (>= 7.0)
@@ -248,8 +248,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 5.0.0)
-  activestorage (>= 5.0.0)
+  activerecord (>= 6.1.0)
+  activestorage (>= 6.1.0)
   appraisal
   aruba
   cucumber

--- a/factory_bot_rails.gemspec
+++ b/factory_bot_rails.gemspec
@@ -8,9 +8,9 @@ Gem::Specification.new do |s|
   s.email = "jferris@thoughtbot.com"
   s.homepage = "https://github.com/thoughtbot/factory_bot_rails"
   s.summary = "factory_bot_rails provides integration between " \
-                  "factory_bot and rails 5.0 or newer"
+                  "factory_bot and Rails 6.1 or newer"
   s.description = "factory_bot_rails provides integration between " \
-                  "factory_bot and rails 5.0 or newer"
+                  "factory_bot and Rails 6.1 or newer"
 
   s.files = Dir["lib/**/*"] + %w[CONTRIBUTING.md LICENSE NEWS.md README.md]
   s.metadata["changelog_uri"] = "https://github.com/thoughtbot/factory_bot_rails/blob/main/NEWS.md"
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.add_runtime_dependency("factory_bot", "~> 6.5")
-  s.add_runtime_dependency("railties", ">= 5.0.0")
+  s.add_runtime_dependency("railties", ">= 6.1.0")
 
-  s.add_development_dependency("activerecord", ">= 5.0.0")
-  s.add_development_dependency("activestorage", ">= 5.0.0")
+  s.add_development_dependency("activerecord", ">= 6.1.0")
+  s.add_development_dependency("activestorage", ">= 6.1.0")
   s.add_development_dependency("mutex_m")
   s.add_development_dependency("sqlite3")
 end


### PR DESCRIPTION
The olders Rails version that we run on CI is 6.1, but our gemspec runtime dependencies ask for Rails 5.0 or higher.

This commit fixes that, adding Rails 6.1 as the minimum required version. When dropping supported Rails versions, let's ensure that the gemspec file is up-to-date.