### PR TITLE
Update `required_ruby_version` to require >= Ruby 3.1

### DIFF
--- a/factory_bot_rails.gemspec
+++ b/factory_bot_rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"] + %w[CONTRIBUTING.md LICENSE NEWS.md README.md]
   s.metadata["changelog_uri"] = "https://github.com/thoughtbot/factory_bot_rails/blob/main/NEWS.md"
   s.require_paths = ["lib"]
-  s.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
+  s.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
   s.executables = []
   s.license = "MIT"
 


### PR DESCRIPTION
It seems that the support of Ruby 3.0 has dropped #507. This PR updates `required_ruby_version` to match it.