### PR TITLE
Add AuthenticationGenerator for users factory creation

### DIFF
--- a/features/generators.feature
+++ b/features/generators.feature
@@ -90,3 +90,21 @@ Feature:
     And I run `bundle exec rails generate model User name:string age:integer` with a clean environment
     Then the output should not contain "test/factories/users.rb"
     And the output should contain "test/fixtures/users.yml"
+
+
+  @rails_8
+  Scenario: The factory_bot_rails authentication generator, coupled with rspec-rails, creates a user factory file
+    When I add "rspec-rails" as a dependency
+    And I run `bundle install --verbose` with a clean environment
+    Then the output should contain "rspec-rails"
+    And I run `bundle exec rails generate authentication` with a clean environment
+    Then the output should contain "spec/factories/users.rb"
+    And the file "spec/factories/users.rb" should contain exactly:
+      """
+      FactoryBot.define do
+        factory :user do
+          email_address { "user@example.com" }
+          password { "password" }
+        end
+      end
+      """

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,6 +11,17 @@ Before do
   setup_aruba
 end
 
+Before("@rails_8") do
+  rails_version = Gem::Version.new(
+    Bundler.load.specs.find { |spec| spec.name == 'rails' }&.version.to_s
+  )
+  required_version = Gem::Version.new('8.0.0')
+
+  if rails_version < required_version
+    skip_this_scenario("Requires Rails 8.0 or higher (current: #{rails_version})")
+  end
+end
+
 if RUBY_PLATFORM == "java"
   Aruba.configure do |config|
     config.before_cmd do

--- a/lib/generators/factory_bot/authentication/authentication_generator.rb
+++ b/lib/generators/factory_bot/authentication/authentication_generator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "generators/factory_bot"
+require "factory_bot_rails"
+require "fileutils"
+
+module FactoryBot
+  module Generators
+    class AuthenticationGenerator < Base
+      def create_users_factory
+        dir = factories_dir
+        FileUtils.mkdir_p(dir)
+
+        target = File.join(dir, "users.rb")
+        if File.exist?(target)
+          say_status :skip, "users.rb already exists at #{target}", :yellow
+        else
+          template "users.rb", target
+          say_status :create, target, :green
+        end
+      end
+
+      private
+
+      def factories_dir
+        if Dir.exist?(Rails.root.join("spec"))
+          Rails.root.join("spec", "factories").to_s
+        else
+          Rails.root.join("test", "factories").to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/factory_bot/authentication/authentication_generator.rb
+++ b/lib/generators/factory_bot/authentication/authentication_generator.rb
@@ -1,33 +1,22 @@
-# frozen_string_literal: true
-
 require "generators/factory_bot"
+require "generators/factory_bot/model/model_generator"
 require "factory_bot_rails"
-require "fileutils"
+
 
 module FactoryBot
   module Generators
-    class AuthenticationGenerator < Base
-      def create_users_factory
-        dir = factories_dir
-        FileUtils.mkdir_p(dir)
+    FixedAttribute = Struct.new(:name, :default)
 
-        target = File.join(dir, "users.rb")
-        if File.exist?(target)
-          say_status :skip, "users.rb already exists at #{target}", :yellow
-        else
-          template "users.rb", target
-          say_status :create, target, :green
-        end
-      end
+    class AuthenticationGenerator < ModelGenerator
+      self.source_paths << File.join(File.dirname(__FILE__), "../model/templates")
 
       private
 
-      def factories_dir
-        if Dir.exist?(Rails.root.join("spec"))
-          Rails.root.join("spec", "factories").to_s
-        else
-          Rails.root.join("test", "factories").to_s
-        end
+      def attributes
+        [
+          FixedAttribute.new(:email_address, "user@example.com"),
+          FixedAttribute.new(:password, "password")
+        ]
       end
     end
   end

--- a/lib/generators/factory_bot/authentication/templates/users.rb
+++ b/lib/generators/factory_bot/authentication/templates/users.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    password { "password123" }
+    password_confirmation { "password123" }
+    email_address { "user#{SecureRandom.hex(3)}@example.com" }
+  end
+end


### PR DESCRIPTION
I couldn't push to #540, so I'm opening a new PR with the original commit and a new one.

---

This change addresses an issue where running the `factory_bot` generator could result in a `factory_bot [not found]` error. The problem occurred due to missing generator definitions and template files.

With this update, the authentication generator is properly defined and includes the necessary templates, ensuring that the `users.rb` factory file is generated regardless of whether the project is using RSpec (`spec/factories`) or Minitest (`test/factories`). This guarantees consistent behavior and avoids generator errors in environments without a `spec` directory.

Previously, projects without a `spec` directory or with incomplete generator/template setup would fail when invoking `factory_bot` generators, making it impossible to scaffold the necessary factory files automatically.

- Added the missing `factory_bot:authentication` generator definition.
- Included `users.rb` template under `templates` directory.
- Implemented logic to detect the test framework and place the generated factory file in the correct directory (`spec/factories` or `test/factories`).
- Ensured generator runs successfully regardless of the presence of a `spec` directory.