### PR TITLE
Remove unused authentication generator file

### DIFF
--- a/lib/generators/factory_bot/authentication/templates/users.rb
+++ b/lib/generators/factory_bot/authentication/templates/users.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :user do
-    password { "password123" }
-    password_confirmation { "password123" }
-    email_address { "user#{SecureRandom.hex(3)}@example.com" }
-  end
-end


### PR DESCRIPTION
Follow-up to https://github.com/thoughtbot/factory_bot_rails/pull/542.

Remove the unused `lib/generators/factory_bot/authentication/templates/users.rb` file.
When using the authentication generator, we generate a `users.rb` file with the following values:

https://github.com/thoughtbot/factory_bot_rails/blob/dfdef4c70a76d36058cf77fc1ccd9904a2bf0beb/lib/generators/factory_bot/authentication/authentication_generator.rb#L14-L19

And this is expected behavior:

https://github.com/thoughtbot/factory_bot_rails/blob/dfdef4c70a76d36058cf77fc1ccd9904a2bf0beb/features/generators.feature#L102-L110

So the values of `lib/generators/factory_bot/authentication/templates/users.rb` are never used. This PR cleans this file up.